### PR TITLE
Fix package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "publiq-platform",
             "dependencies": {
                 "@inertiajs/inertia": "^0.11.1",
                 "@inertiajs/inertia-react": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "publiq-platform",
     "private": true,
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
### Fixed

- Added a name to `package.json`. Otherwise the name in `package.lock` always gets overwritten to `html` when running `npm install`
