### PR TITLE
PPF-77 Bugfix migrated v1 accounts

### DIFF
--- a/database/migrations/2022_11_30_145724_update_action_events_table.php
+++ b/database/migrations/2022_11_30_145724_update_action_events_table.php
@@ -10,7 +10,7 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('action_events', function (Blueprint $table) {
-            $table->string('user_id', 42)->change();
+            $table->string('user_id', 255)->change();
         });
     }
 

--- a/database/migrations/2022_11_30_145724_update_action_events_table.php
+++ b/database/migrations/2022_11_30_145724_update_action_events_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+
+    public function up(): void
+    {
+        Schema::table('action_events', function (Blueprint $table) {
+            $table->string('user_id', 42)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('action_events', function (Blueprint $table) {
+            $table->string('user_id', 36)->change();
+        });
+    }
+};

--- a/database/migrations/2022_11_30_145724_update_action_events_table.php
+++ b/database/migrations/2022_11_30_145724_update_action_events_table.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 return new class () extends Migration {
-
     public function up(): void
     {
         Schema::table('action_events', function (Blueprint $table) {


### PR DESCRIPTION
### Changed

- Length of column `user_id` in `action_events`

### Fixed

- Users with a migrated v1 account(with `UserId` like `auth0|<<UUID>>` can save items without getting an error.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-77
