### PR TITLE
Remove incorrect/redundant keywords from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "cultuurnet/publiq-platform",
     "type": "project",
     "description": "Publiq platform",
-    "keywords": ["UDB3", "Publiq"],
     "license": "MIT",
     "require": {
         "php": "^8.1.0",


### PR DESCRIPTION
### Removed

Removed the `keywords` from `composer.json` because:
- We won't publish this on packagist as it's an application, so no one will be searching on these keywords
- This app is not specific to UDB3
- The name "Publiq" is also in the name and description

---

(Just happened to notice this)
