### PR TITLE
Fix Sentry crash in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ $ make up
 $ make down
 ```
 
-- Start an interactive shell session
+- Start an interactive bash session
 ```
-$ make shell
+$ make bash
 ```
 
 - Install/update the backend and frontend applications

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -47,8 +47,10 @@ final class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             if (app()->bound('sentry')) {
                 configureScope(function (Scope $scope): void {
-                    $user = Auth::user();
-                    $scope->setUser(['id' => $user->id ?? 'guest']);
+                    if (!app()->runningInConsole()) {
+                        $user = Auth::user();
+                        $scope->setUser(['id' => $user->id ?? 'guest']);
+                    }
                 });
 
                 app('sentry')->captureException($e);


### PR DESCRIPTION
### Fixed

- Fixed `Auth::user()` being called (and crashing) when an exception is thrown in a CLI context.
- Fixed incorrect `make shell` in README (was later renamed to `make bash`)
