### PR TITLE
PPF-102 Create UiTiD v1 consumer(s) for new integration

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -86,6 +86,33 @@ AUTH0_PROD_TENANT_DOMAIN=publiq-dev.eu.auth0.com
 AUTH0_PROD_TENANT_CLIENT_ID=
 AUTH0_PROD_TENANT_CLIENT_SECRET=
 
+# MUST always be set to UiTiD v1 ACC environment config except for the .env for the production app!
+# Otherwise local/staging/acceptance/testing environments of publiq platform will create real consumers on test/prod.
+UITID_V1_ACC_URL=https://acc.uitid.be/uitid/rest/
+UITID_V1_ACC_CONSUMER_KEY=
+UITID_V1_ACC_CONSUMER_SECRET=
+UITID_V1_ACC_GROUPS_ENTRY_API="3,24380,24640"
+UITID_V1_ACC_GROUPS_SEARCH_API="3,24379"
+UITID_V1_ACC_GROUPS_WIDGETS="3,24378"
+
+# MUST always be set to UiTiD v1 ACC environment config except for the .env for the production app!
+# Otherwise local/staging/acceptance/testing environments of publiq platform will create real consumers on test/prod.
+UITID_V1_TEST_URL=https://acc.uitid.be/uitid/rest/
+UITID_V1_TEST_CONSUMER_KEY=
+UITID_V1_TEST_CONSUMER_SECRET=
+UITID_V1_TEST_GROUPS_ENTRY_API="3,24380,24640"
+UITID_V1_TEST_GROUPS_SEARCH_API="3,24379"
+UITID_V1_TEST_GROUPS_WIDGETS="3,24378"
+
+# MUST always be set to UiTiD v1 ACC environment config except for the .env for the production app!
+# Otherwise local/staging/acceptance/testing environments of publiq platform will create real consumers on test/prod.
+UITID_V1_PROD_URL=https://acc.uitid.be/uitid/rest/
+UITID_V1_PROD_CONSUMER_KEY=
+UITID_V1_PROD_CONSUMER_SECRET=
+UITID_V1_PROD_GROUPS_ENTRY_API="3,24380,24640"
+UITID_V1_PROD_GROUPS_SEARCH_API="3,24379"
+UITID_V1_PROD_GROUPS_WIDGETS="3,24378"
+
 INSIGHTLY_HOST=https://api.insight.ly/v3.1/
 INSIGHTLY_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,33 @@ AUTH0_PROD_TENANT_DOMAIN=publiq-dev.eu.auth0.com
 AUTH0_PROD_TENANT_CLIENT_ID=
 AUTH0_PROD_TENANT_CLIENT_SECRET=
 
+# MUST always be set to UiTiD v1 ACC environment config except for the .env for the production app!
+# Otherwise local/staging/acceptance/testing environments of publiq platform will create real consumers on test/prod.
+UITID_V1_ACC_URL=https://acc.uitid.be/uitid/rest/
+UITID_V1_ACC_CONSUMER_KEY=
+UITID_V1_ACC_CONSUMER_SECRET=
+UITID_V1_ACC_GROUPS_ENTRY_API="3,24380,24640"
+UITID_V1_ACC_GROUPS_SEARCH_API="3,24379"
+UITID_V1_ACC_GROUPS_WIDGETS="3,24378"
+
+# MUST always be set to UiTiD v1 ACC environment config except for the .env for the production app!
+# Otherwise local/staging/acceptance/testing environments of publiq platform will create real consumers on test/prod.
+UITID_V1_TEST_URL=https://acc.uitid.be/uitid/rest/
+UITID_V1_TEST_CONSUMER_KEY=
+UITID_V1_TEST_CONSUMER_SECRET=
+UITID_V1_TEST_GROUPS_ENTRY_API="3,24380,24640"
+UITID_V1_TEST_GROUPS_SEARCH_API="3,24379"
+UITID_V1_TEST_GROUPS_WIDGETS="3,24378"
+
+# MUST always be set to UiTiD v1 ACC environment config except for the .env for the production app!
+# Otherwise local/staging/acceptance/testing environments of publiq platform will create real consumers on test/prod.
+UITID_V1_PROD_URL=https://acc.uitid.be/uitid/rest/
+UITID_V1_PROD_CONSUMER_KEY=
+UITID_V1_PROD_CONSUMER_SECRET=
+UITID_V1_PROD_GROUPS_ENTRY_API="3,24380,24640"
+UITID_V1_PROD_GROUPS_SEARCH_API="3,24379"
+UITID_V1_PROD_GROUPS_WIDGETS="3,24378"
+
 INSIGHTLY_HOST=https://api.insight.ly/v3.1/
 INSIGHTLY_API_KEY=
 

--- a/app/Auth0/Auth0ClusterSDK.php
+++ b/app/Auth0/Auth0ClusterSDK.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Auth0;
 
 use App\Domain\Integrations\Integration;
-use Illuminate\Support\Collection;
 
 final class Auth0ClusterSDK
 {
@@ -22,16 +21,14 @@ final class Auth0ClusterSDK
     }
 
     /**
-     * @return Collection<int, Auth0Client>
+     * @return Auth0Client[]
      */
-    public function createClientsForIntegration(Integration $integration): Collection
+    public function createClientsForIntegration(Integration $integration): array
     {
-        return collect(
-            array_values(
-                array_map(
-                    static fn (Auth0TenantSDK $sdk) => $sdk->createClientForIntegration($integration),
-                    $this->auth0TenantSDKs
-                )
+        return array_values(
+            array_map(
+                static fn (Auth0TenantSDK $sdk) => $sdk->createClientForIntegration($integration),
+                $this->auth0TenantSDKs
             )
         );
     }

--- a/app/Auth0/Listeners/CreateClients.php
+++ b/app/Auth0/Listeners/CreateClients.php
@@ -26,6 +26,6 @@ final class CreateClients implements ShouldQueue
     {
         $integration = $this->integrationRepository->getById($integrationCreated->id);
         $auth0Clients = $this->auth0ClusterSDK->createClientsForIntegration($integration);
-        $this->auth0ClientRepository->save(...$auth0Clients);
+        $this->auth0ClientRepository->save(...$auth0Clients->toArray());
     }
 }

--- a/app/Auth0/Listeners/CreateClients.php
+++ b/app/Auth0/Listeners/CreateClients.php
@@ -26,6 +26,6 @@ final class CreateClients implements ShouldQueue
     {
         $integration = $this->integrationRepository->getById($integrationCreated->id);
         $auth0Clients = $this->auth0ClusterSDK->createClientsForIntegration($integration);
-        $this->auth0ClientRepository->save(...$auth0Clients->toArray());
+        $this->auth0ClientRepository->save(...$auth0Clients);
     }
 }

--- a/app/UiTiDv1/Listeners/CreateConsumers.php
+++ b/app/UiTiDv1/Listeners/CreateConsumers.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1\Listeners;
+
+use App\Domain\Integrations\Events\IntegrationCreated;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1ClusterSDK;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+final class CreateConsumers implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly UiTiDv1ClusterSDK $clusterSDK,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly UiTiDv1ConsumerRepository $consumerRepository
+    ) {
+    }
+
+    public function handle(IntegrationCreated $integrationCreated): void
+    {
+        $integration = $this->integrationRepository->getById($integrationCreated->id);
+        $consumers = $this->clusterSDK->createConsumersForIntegration($integration);
+        $this->consumerRepository->save(...$consumers);
+    }
+}

--- a/app/UiTiDv1/Models/UiTiDv1ConsumerModel.php
+++ b/app/UiTiDv1/Models/UiTiDv1ConsumerModel.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1\Models;
+
+use App\UiTiDv1\UiTiDv1Consumer;
+use App\UiTiDv1\UiTiDv1Environment;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Ramsey\Uuid\Uuid;
+
+final class UiTiDv1ConsumerModel extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'uitidv1_consumers';
+    protected $primaryKey = null;
+    public $incrementing = false;
+
+    protected $fillable = [
+        'integration_id',
+        'consumer_key',
+        'consumer_secret',
+        'api_key',
+        'environment',
+    ];
+
+    public function toDomain(): UiTiDv1Consumer
+    {
+        return new UiTiDv1Consumer(
+            Uuid::fromString($this->integration_id),
+            $this->consumer_key,
+            $this->consumer_secret,
+            $this->api_key,
+            UiTiDv1Environment::from($this->environment)
+        );
+    }
+}

--- a/app/UiTiDv1/OAuth1.php
+++ b/app/UiTiDv1/OAuth1.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use GuzzleHttp\Psr7\Query;
+use GuzzleHttp\Subscriber\Oauth\Oauth1 as BaseOauth1;
+use Psr\Http\Message\RequestInterface;
+
+final class OAuth1 extends BaseOauth1
+{
+    /**
+     * Overridden to fix two issues in the base method when generating the base string for requests that have one or
+     * more parameters with multiple values (like parameter=value1&parameter=value2).
+     *
+     * @see https://github.com/guzzle/oauth-subscriber/issues/69
+     * @see https://github.com/guzzle/oauth-subscriber/pull/70
+     */
+    protected function createBaseString(RequestInterface $request, array $params): string
+    {
+        $url = (string) $request->getUri()->withQuery('');
+
+        // Fix 1: Make sure that parameters with multiple values are sorted. They have to be sorted specifically by
+        // their string value to generate a correct base string. For example [30,2,100] must be sorted as [100,2,30].
+        $params = array_map(
+            static function (mixed $value): mixed {
+                if (is_array($value)) {
+                    sort($value, SORT_STRING);
+                }
+                return $value;
+            },
+            $params
+        );
+
+        // Fix 2: Make sure to use GuzzleHttp\Psr7\Query::build() instead of http_build_query() to avoid parameters with
+        // multiple values being encoded with a [] suffix.
+        $query = Query::build($params);
+
+        return strtoupper($request->getMethod())
+            . '&' . rawurlencode($url)
+            . '&' . rawurlencode($query);
+    }
+}

--- a/app/UiTiDv1/Repositories/EloquentUiTiDv1ConsumerRepository.php
+++ b/app/UiTiDv1/Repositories/EloquentUiTiDv1ConsumerRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1\Repositories;
+
+use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
+use App\UiTiDv1\UiTiDv1Consumer;
+use Illuminate\Support\Facades\DB;
+use Ramsey\Uuid\UuidInterface;
+
+final class EloquentUiTiDv1ConsumerRepository implements UiTiDv1ConsumerRepository
+{
+    public function save(UiTiDv1Consumer ...$uitidv1Consumers): void
+    {
+        if (count($uitidv1Consumers) === 0) {
+            return;
+        }
+
+        DB::transaction(static function () use ($uitidv1Consumers) {
+            foreach ($uitidv1Consumers as $uitidv1Consumer) {
+                UiTiDv1ConsumerModel::query()
+                    ->updateOrCreate(
+                        [
+                            'consumer_key' => $uitidv1Consumer->consumerKey,
+                            'environment' => $uitidv1Consumer->environment->value,
+                        ],
+                        [
+                            'integration_id' => $uitidv1Consumer->integrationId->toString(),
+                            'consumer_key' => $uitidv1Consumer->consumerKey,
+                            'consumer_secret' => $uitidv1Consumer->consumerSecret,
+                            'api_key' => $uitidv1Consumer->apiKey,
+                            'environment' => $uitidv1Consumer->environment->value,
+                        ]
+                    );
+            }
+        });
+    }
+
+    public function getByIntegrationId(UuidInterface $integrationId): array
+    {
+        return UiTiDv1ConsumerModel::query()
+            ->where('integration_id', $integrationId->toString())
+            ->get()
+            ->map(static fn (UiTiDv1ConsumerModel $model) => $model->toDomain())
+            ->toArray();
+    }
+}

--- a/app/UiTiDv1/Repositories/UiTiDv1ConsumerRepository.php
+++ b/app/UiTiDv1/Repositories/UiTiDv1ConsumerRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1\Repositories;
+
+use App\UiTiDv1\UiTiDv1Consumer;
+use Ramsey\Uuid\UuidInterface;
+
+interface UiTiDv1ConsumerRepository
+{
+    public function save(UiTiDv1Consumer ...$uitidv1Consumers): void;
+
+    /**
+     * @return UiTiDv1Consumer[]
+     */
+    public function getByIntegrationId(UuidInterface $integrationId): array;
+}

--- a/app/UiTiDv1/UiTiDv1ClusterSDK.php
+++ b/app/UiTiDv1/UiTiDv1ClusterSDK.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use App\Domain\Integrations\Integration;
+
+final class UiTiDv1ClusterSDK
+{
+    /**
+     * @var UiTiDv1EnvironmentSDK[]
+     */
+    private array $uitidv1EnvironmentSDKs = [];
+
+    public function __construct(UiTiDv1EnvironmentSDK ...$uitidv1EnvironmentSDKs)
+    {
+        foreach ($uitidv1EnvironmentSDKs as $uitidv1EnvironmentSDK) {
+            $this->uitidv1EnvironmentSDKs[$uitidv1EnvironmentSDK->environment->value] = $uitidv1EnvironmentSDK;
+        }
+    }
+
+    /**
+     * @return UiTiDv1Consumer[]
+     */
+    public function createConsumersForIntegration(Integration $integration): array
+    {
+        return array_values(
+            array_map(
+                static fn (UiTiDv1EnvironmentSDK $sdk) => $sdk->createConsumerForIntegration($integration),
+                $this->uitidv1EnvironmentSDKs
+            )
+        );
+    }
+}

--- a/app/UiTiDv1/UiTiDv1Consumer.php
+++ b/app/UiTiDv1/UiTiDv1Consumer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use Ramsey\Uuid\UuidInterface;
+
+final class UiTiDv1Consumer
+{
+    public function __construct(
+        public readonly UuidInterface $integrationId,
+        public readonly string $consumerKey,
+        public readonly string $consumerSecret,
+        public readonly string $apiKey,
+        public readonly UiTiDv1Environment $environment
+    ) {
+    }
+}

--- a/app/UiTiDv1/UiTiDv1Environment.php
+++ b/app/UiTiDv1/UiTiDv1Environment.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+enum UiTiDv1Environment: string
+{
+    case Acceptance = 'acc';
+    case Testing = 'test';
+    case Production = 'prod';
+}

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -9,7 +9,6 @@ use App\Json;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
 use Psr\Http\Message\ResponseInterface;
 use SimpleXMLElement;
@@ -73,13 +72,15 @@ final class UiTiDv1EnvironmentSDK
 
     private function sendPostRequest(string $path, array $formData): ResponseInterface
     {
-        $headers = ['content-type' => 'application/x-www-form-urlencoded'];
+        // Make sure to encode the form data using Query::build() and use the "body" option, as opposed to using the
+        // "form_params" option. While form_params supports parameters with multiple values, it encodes them with a []
+        // suffix which is not supported by UiTiD v1.
         $options = [
-            'form_params' => $formData,
             'http_errors' => false,
+            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+            'body' => Query::build($formData),
         ];
-        $request = new Request('POST', $path, $headers);
-        $response = $this->httpClient->send($request, $options);
+        $response = $this->httpClient->request('POST', $path, $options);
 
         $status = $response->getStatusCode();
         if ($status < 200 || $status > 299) {

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -75,8 +75,8 @@ final class UiTiDv1EnvironmentSDK
             'form_params' => $formData,
             'http_errors' => false,
         ];
-        $request = new Request('POST', $path, $headers, $options);
-        $response = $this->httpClient->send($request);
+        $request = new Request('POST', $path, $headers);
+        $response = $this->httpClient->send($request, $options);
 
         $status = $response->getStatusCode();
         if ($status < 200 || $status > 299) {

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -19,7 +19,8 @@ final class UiTiDv1EnvironmentSDK
         public readonly UiTiDv1Environment $environment,
         private readonly ClientInterface $httpClient,
         private readonly array $permissionGroupsPerIntegrationType
-    ) {}
+    ) {
+    }
 
     public function createConsumerForIntegration(Integration $integration): UiTiDv1Consumer
     {
@@ -54,7 +55,7 @@ final class UiTiDv1EnvironmentSDK
             'consumer_key' => $consumerKey,
             'consumer_secret' => $consumerSecret,
             'token' => '',
-            'token_secret' => ''
+            'token_secret' => '',
         ]);
         $handlerStack->push($middleware);
 
@@ -65,7 +66,7 @@ final class UiTiDv1EnvironmentSDK
             [
                 'base_uri' => $baseUrl,
                 'handler' => $handlerStack,
-                'auth' => 'oauth'
+                'auth' => 'oauth',
             ]
         );
     }

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -32,7 +32,7 @@ final class UiTiDv1EnvironmentSDK
             'group' => $this->permissionGroupsPerIntegrationType[$integration->type->value] ?? [],
         ];
 
-        $response = $this->sendPostRequest('/serviceconsumer', $formData);
+        $response = $this->sendPostRequest('serviceconsumer', $formData);
 
         // Easiest way to convert XML to an array is by encoding an SimpleXMLELement as JSON and then decoding it again.
         // This way we don't need to deal with XPath to read the values.
@@ -58,6 +58,9 @@ final class UiTiDv1EnvironmentSDK
             'token_secret' => ''
         ]);
         $handlerStack->push($middleware);
+
+        // Make sure the base URL always has a single trailing slash.
+        $baseUrl = rtrim($baseUrl, '/') . '/';
 
         return new Client(
             [

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -9,7 +9,7 @@ use App\Json;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use GuzzleHttp\Psr7\Query;
 use Psr\Http\Message\ResponseInterface;
 use SimpleXMLElement;
 
@@ -50,7 +50,7 @@ final class UiTiDv1EnvironmentSDK
         string $consumerSecret,
     ): ClientInterface {
         $handlerStack = HandlerStack::create();
-        $middleware = new Oauth1([
+        $middleware = new OAuth1([
             'consumer_key' => $consumerKey,
             'consumer_secret' => $consumerSecret,
             'token' => '',

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use App\Domain\Integrations\Integration;
+use App\Json;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Subscriber\Oauth\Oauth1;
+use Psr\Http\Message\ResponseInterface;
+use SimpleXMLElement;
+
+final class UiTiDv1EnvironmentSDK
+{
+    public function __construct(
+        public readonly UiTiDv1Environment $environment,
+        private readonly ClientInterface $httpClient,
+        private readonly array $permissionGroupsPerIntegrationType
+    ) {}
+
+    public function createConsumerForIntegration(Integration $integration): UiTiDv1Consumer
+    {
+        $name = sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
+
+        $formData = [
+            'name' => $name,
+            'description' => $integration->description,
+            'group' => $this->permissionGroupsPerIntegrationType[$integration->type->value] ?? [],
+        ];
+
+        $response = $this->sendPostRequest('/serviceconsumer', $formData);
+
+        // Easiest way to convert XML to an array is by encoding an SimpleXMLELement as JSON and then decoding it again.
+        // This way we don't need to deal with XPath to read the values.
+        $xml = new SimpleXMLElement($response->getBody()->getContents());
+        $data = Json::decodeAssociatively(Json::encode($xml));
+        $consumerKey = $data['consumerKey'];
+        $consumerSecret = $data['consumerSecret'];
+        $apiKey = $data['apiKeySapi3'];
+
+        return new UiTiDv1Consumer($integration->id, $consumerKey, $consumerSecret, $apiKey, $this->environment);
+    }
+
+    public static function createOAuth1HttpClient(
+        string $baseUrl,
+        string $consumerKey,
+        string $consumerSecret,
+    ): ClientInterface {
+        $handlerStack = HandlerStack::create();
+        $middleware = new Oauth1([
+            'consumer_key' => $consumerKey,
+            'consumer_secret' => $consumerSecret,
+            'token' => '',
+            'token_secret' => ''
+        ]);
+        $handlerStack->push($middleware);
+
+        return new Client(
+            [
+                'base_uri' => $baseUrl,
+                'handler' => $handlerStack,
+                'auth' => 'oauth'
+            ]
+        );
+    }
+
+    private function sendPostRequest(string $path, array $formData): ResponseInterface
+    {
+        $headers = ['content-type' => 'application/x-www-form-urlencoded'];
+        $options = [
+            'form_params' => $formData,
+            'http_errors' => false,
+        ];
+        $request = new Request('POST', $path, $headers, $options);
+        $response = $this->httpClient->send($request);
+
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status > 299) {
+            throw UiTiDv1SDKException::forResponse($response);
+        }
+
+        return $response;
+    }
+}

--- a/app/UiTiDv1/UiTiDv1SDKException.php
+++ b/app/UiTiDv1/UiTiDv1SDKException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+final class UiTiDv1SDKException extends RuntimeException
+{
+    public static function forResponse(ResponseInterface $response): self
+    {
+        $statusCode = $response->getStatusCode();
+        $body = $response->getBody()->getContents();
+
+        return new self(
+            'UiTiD v1 responded with status code ' . $statusCode . ' instead of 2xx. Response body: ' . $body,
+            $statusCode
+        );
+    }
+}

--- a/app/UiTiDv1/UiTiDv1ServiceProvider.php
+++ b/app/UiTiDv1/UiTiDv1ServiceProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use App\Domain\Integrations\Events\IntegrationCreated;
+use App\UiTiDv1\Listeners\CreateConsumers;
+use App\UiTiDv1\Repositories\EloquentUiTiDv1ConsumerRepository;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+
+final class UiTiDv1ServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(UiTiDv1ConsumerRepository::class, EloquentUiTiDv1ConsumerRepository::class);
+
+        $this->app->singleton(UiTiDv1ClusterSDK::class, function () {
+            // Filter out environments with missing config (consider them disabled)
+            $environmentsConfig = array_filter(
+                config('uitidv1.environments'),
+                static fn (array $environmentConfig) =>
+                    $environmentConfig['baseUrl'] !== '' &&
+                    $environmentConfig['consumerKey'] !== '' &&
+                    $environmentConfig['consumerSecret'] !== ''
+            );
+
+            // Create a cluster with an environment SDK per (enabled) environment config
+            return new UiTiDv1ClusterSDK(
+                ...array_map(
+                    static fn (array $environmentConfig, string $environment) => new UiTiDv1EnvironmentSDK(
+                        UiTiDv1Environment::from($environment),
+                        UiTiDv1EnvironmentSDK::createOAuth1HttpClient(
+                            $environmentConfig['baseUrl'],
+                            $environmentConfig['consumerKey'],
+                            $environmentConfig['consumerSecret']
+                        ),
+                        // Take the groups per integration type and convert each value from a comma-separated string
+                        // to an array.
+                        array_map(
+                            static fn (string $groups) => explode(',', str_replace(' ', '', $groups)),
+                            $environmentConfig['groups']
+                        )
+                    ),
+                    $environmentsConfig,
+                    array_keys($environmentsConfig)
+                )
+            );
+        });
+
+        // May always be registered even if there are no configured environments, because in that case the cluster SDK
+        // will just not have any environment SDKs to loop over and so it simply won't do anything.
+        // But it won't crash either.
+        Event::listen(IntegrationCreated::class, [CreateConsumers::class, 'handle']);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": "^8.1.0",
         "auth0/login": "^7.2",
         "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/oauth-subscriber": "^0.6",
         "inertiajs/inertia-laravel": "^0.6.3",
         "laravel/framework": "^9.19",
         "laravel/horizon": "^5.10",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1.0",
+        "ext-simplexml": "*",
         "auth0/login": "^7.2",
         "guzzlehttp/guzzle": "^7.2",
         "guzzlehttp/oauth-subscriber": "^0.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a45b4d827d6ae55ed04953f8722d7da",
+    "content-hash": "1bde9af2b7c433cf5165c2cd3fa308d7",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -11362,7 +11362,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1.0"
+        "php": "^8.1.0",
+        "ext-simplexml": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64989dd3b0cff50e05ceeb0a08db10da",
+    "content-hash": "2a45b4d827d6ae55ed04953f8722d7da",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -1352,6 +1352,65 @@
                 }
             ],
             "time": "2022-08-28T15:39:27+00:00"
+        },
+        {
+            "name": "guzzlehttp/oauth-subscriber",
+            "version": "0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/oauth-subscriber.git",
+                "reference": "8d6cab29f8397e5712d00a383eeead36108a3c1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/oauth-subscriber/zipball/8d6cab29f8397e5712d00a383eeead36108a3c1f",
+                "reference": "8d6cab29f8397e5712d00a383eeead36108a3c1f",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.5|^7.2",
+                "guzzlehttp/psr7": "^1.7|^2.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|^9.3.3"
+            },
+            "suggest": {
+                "ext-openssl": "Required to sign using RSA-SHA1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Subscriber\\Oauth\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle OAuth 1.0 subscriber",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "oauth"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/oauth-subscriber/issues",
+                "source": "https://github.com/guzzle/oauth-subscriber/tree/0.6.0"
+            },
+            "time": "2021-07-13T12:01:32+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/config/app.php
+++ b/config/app.php
@@ -199,6 +199,7 @@ return [
         App\Providers\HorizonServiceProvider::class,
         App\Providers\NovaServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\UiTiDv1\UiTiDv1ServiceProvider::class,
 
     ],
 

--- a/config/uitidv1.php
+++ b/config/uitidv1.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // UiTiD v1 environments configuration, used to store/update consumers in UiTiD v1.
+    // Note that local/staging/acceptance/testing environments of publiq platform should actually use the ACC
+    // environment of UiTiD v1 as replacements for the test/prod environments of UiTiD v1. Otherwise, they will create
+    // real clients on the test/prod environments which we do not want.
+    'environments' => [
+        'acc' => [
+            'baseUrl' => env('UITID_V1_ACC_URL'),
+            'consumerKey' => env('UITID_V1_ACC_CONSUMER_KEY'),
+            'consumerSecret' => env('UITID_V1_ACC_CONSUMER_SECRET'),
+            'groups' => [
+                'entry-api' => env('UITID_V1_ACC_GROUPS_ENTRY_API'),
+                'search-api' => env('UITID_V1_ACC_GROUPS_SEARCH_API'),
+                'widgets' => env('UITID_V1_ACC_GROUPS_WIDGETS'),
+            ],
+        ],
+        'test' => [
+            'baseUrl' => env('UITID_V1_TEST_URL'),
+            'consumerKey' => env('UITID_V1_TEST_CONSUMER_KEY'),
+            'consumerSecret' => env('UITID_V1_TEST_CONSUMER_SECRET'),
+            'groups' => [
+                'entry-api' => env('UITID_V1_TEST_GROUPS_ENTRY_API'),
+                'search-api' => env('UITID_V1_TEST_GROUPS_SEARCH_API'),
+                'widgets' => env('UITID_V1_TEST_GROUPS_WIDGETS'),
+            ],
+        ],
+        'prod' => [
+            'baseUrl' => env('UITID_V1_PROD_URL'),
+            'consumerKey' => env('UITID_V1_PROD_CONSUMER_KEY'),
+            'consumerSecret' => env('UITID_V1_PROD_CONSUMER_SECRET'),
+            'groups' => [
+                'entry-api' => env('UITID_V1_PROD_GROUPS_ENTRY_API'),
+                'search-api' => env('UITID_V1_PROD_GROUPS_SEARCH_API'),
+                'widgets' => env('UITID_V1_PROD_GROUPS_WIDGETS'),
+            ],
+        ],
+    ],
+];

--- a/database/migrations/2023_01_03_115900_create_uitidv1_consumers_table.php
+++ b/database/migrations/2023_01_03_115900_create_uitidv1_consumers_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('uitidv1_consumers', static function (Blueprint $table) {
+            $table->uuid('integration_id')->index();
+            $table->string('consumer_key')->index();
+            $table->string('consumer_secret');
+            $table->string('api_key');
+            $table->string('environment')->index();
+            $table->unique(['integration_id', 'consumer_key']);
+            $table->unique(['consumer_key', 'environment']);
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('uitidv1_consumers');
+    }
+};

--- a/tests/UiTiDv1/CreatesMockUiTiDv1ClusterSDK.php
+++ b/tests/UiTiDv1/CreatesMockUiTiDv1ClusterSDK.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UiTiDv1;
+
+use App\UiTiDv1\UiTiDv1ClusterSDK;
+use App\UiTiDv1\UiTiDv1Environment;
+use App\UiTiDv1\UiTiDv1EnvironmentSDK;
+use GuzzleHttp\ClientInterface;
+
+trait CreatesMockUiTiDv1ClusterSDK
+{
+    public function createMockUiTiDv1ClusterSDK(ClientInterface $httpClient): UiTiDv1ClusterSDK
+    {
+        return new UiTiDv1ClusterSDK(
+            new UiTiDv1EnvironmentSDK(
+                UiTiDv1Environment::Acceptance,
+                $httpClient,
+                [
+                    'entry-api' => [1,2],
+                    'search-api' => [3],
+                    'widgets' => [4,5,6],
+                ]
+            ),
+            new UiTiDv1EnvironmentSDK(
+                UiTiDv1Environment::Testing,
+                $httpClient,
+                [
+                    'entry-api' => [7,8],
+                    'search-api' => [9],
+                    'widgets' => [10,11,12],
+                ]
+            ),
+            new UiTiDv1EnvironmentSDK(
+                UiTiDv1Environment::Production,
+                $httpClient,
+                [
+                    'entry-api' => [13,14],
+                    'search-api' => [15],
+                    'widgets' => [16,17,18],
+                ]
+            ),
+        );
+    }
+}

--- a/tests/UiTiDv1/Listeners/CreateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/CreateConsumersTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UiTiDv1\Listeners;
+
+use App\Domain\Integrations\Events\IntegrationCreated;
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationStatus;
+use App\Domain\Integrations\IntegrationType;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\UiTiDv1\Listeners\CreateConsumers;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1Consumer;
+use App\UiTiDv1\UiTiDv1Environment;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
+
+final class CreateConsumersTest extends TestCase
+{
+    use CreatesMockUiTiDv1ClusterSDK;
+
+    private ClientInterface&MockObject $httpClient;
+    private IntegrationRepository&MockObject $integrationRepository;
+    private UiTiDv1ConsumerRepository&MockObject $consumerRepository;
+    private CreateConsumers $createConsumers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
+        $this->consumerRepository = $this->createMock(UiTiDv1ConsumerRepository::class);
+
+        $this->createConsumers = new CreateConsumers(
+            $this->createMockUiTiDv1ClusterSDK($this->httpClient),
+            $this->integrationRepository,
+            $this->consumerRepository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_new_consumer_in_every_configured_environment(): void
+    {
+        $integrationId = Uuid::uuid4();
+        $integration = new Integration(
+            $integrationId,
+            IntegrationType::EntryApi,
+            'Mock Integration',
+            'Mock description',
+            Uuid::uuid4(),
+            IntegrationStatus::Draft,
+            []
+        );
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with($integrationId)
+            ->willReturn($integration);
+
+        $this->httpClient->expects($this->exactly(3))
+            ->method('request')
+            ->withConsecutive(
+                [
+                    'POST',
+                    'serviceconsumer',
+                    [
+                        'http_errors' => false,
+                        'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                        'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=1&group=2',
+                    ],
+                ],
+                [
+                    'POST',
+                    'serviceconsumer',
+                    [
+                        'http_errors' => false,
+                        'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                        'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=7&group=8',
+                    ],
+                ],
+                [
+                    'POST',
+                    'serviceconsumer',
+                    [
+                        'http_errors' => false,
+                        'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                        'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=13&group=14',
+                    ],
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                new Response(200, [], file_get_contents(__DIR__ . '/consumer1.xml')),
+                new Response(200, [], file_get_contents(__DIR__ . '/consumer2.xml')),
+                new Response(200, [], file_get_contents(__DIR__ . '/consumer3.xml')),
+            );
+
+        $expectedConsumers = [
+            new UiTiDv1Consumer(
+                $integrationId,
+                'mock-consumer-key-1',
+                'mock-consumer-secret-1',
+                'mock-api-key-1',
+                UiTiDv1Environment::Acceptance
+            ),
+            new UiTiDv1Consumer(
+                $integrationId,
+                'mock-consumer-key-2',
+                'mock-consumer-secret-2',
+                'mock-api-key-2',
+                UiTiDv1Environment::Testing
+            ),
+            new UiTiDv1Consumer(
+                $integrationId,
+                'mock-consumer-key-3',
+                'mock-consumer-secret-3',
+                'mock-api-key-3',
+                UiTiDv1Environment::Production
+            ),
+        ];
+
+        $this->consumerRepository->expects($this->once())
+            ->method('save')
+            ->with(...$expectedConsumers);
+
+        $this->createConsumers->handle(new IntegrationCreated($integrationId));
+    }
+}

--- a/tests/UiTiDv1/Listeners/consumer1.xml
+++ b/tests/UiTiDv1/Listeners/consumer1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<consumer xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.1/FINAL">
+    <consumerKey>mock-consumer-key-1</consumerKey>
+    <consumerSecret>mock-consumer-secret-1</consumerSecret>
+    <description>Mock description</description>
+    <creationDate>2023-01-02T15:44Z</creationDate>
+    <id>4135</id>
+    <name>Mock Integration</name>
+    <status>ACTIVE</status>
+    <apiKeySapi3>mock-api-key-1</apiKeySapi3>
+    <confirmationMailEnabled>true</confirmationMailEnabled>
+    <registrationType>NICK</registrationType>
+    <skipLightEmailVerification>false</skipLightEmailVerification>
+</consumer>

--- a/tests/UiTiDv1/Listeners/consumer2.xml
+++ b/tests/UiTiDv1/Listeners/consumer2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<consumer xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.1/FINAL">
+    <consumerKey>mock-consumer-key-2</consumerKey>
+    <consumerSecret>mock-consumer-secret-2</consumerSecret>
+    <description>Mock description</description>
+    <creationDate>2023-01-02T15:44Z</creationDate>
+    <id>4135</id>
+    <name>Mock Integration</name>
+    <status>ACTIVE</status>
+    <apiKeySapi3>mock-api-key-2</apiKeySapi3>
+    <confirmationMailEnabled>true</confirmationMailEnabled>
+    <registrationType>NICK</registrationType>
+    <skipLightEmailVerification>false</skipLightEmailVerification>
+</consumer>

--- a/tests/UiTiDv1/Listeners/consumer3.xml
+++ b/tests/UiTiDv1/Listeners/consumer3.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<consumer xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:cdb="http://www.cultuurdatabank.com/XMLSchema/CdbXSD/3.1/FINAL">
+    <consumerKey>mock-consumer-key-3</consumerKey>
+    <consumerSecret>mock-consumer-secret-3</consumerSecret>
+    <description>Mock description</description>
+    <creationDate>2023-01-02T15:44Z</creationDate>
+    <id>4135</id>
+    <name>Mock Integration</name>
+    <status>ACTIVE</status>
+    <apiKeySapi3>mock-api-key-3</apiKeySapi3>
+    <confirmationMailEnabled>true</confirmationMailEnabled>
+    <registrationType>NICK</registrationType>
+    <skipLightEmailVerification>false</skipLightEmailVerification>
+</consumer>

--- a/tests/UiTiDv1/Repositories/EloquentUiTiDv1ConsumerRepositoryTest.php
+++ b/tests/UiTiDv1/Repositories/EloquentUiTiDv1ConsumerRepositoryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UiTiDv1\Repositories;
+
+use App\UiTiDv1\Repositories\EloquentUiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1Consumer;
+use App\UiTiDv1\UiTiDv1Environment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Ramsey\Uuid\Uuid;
+use Tests\TestCase;
+
+final class EloquentUiTiDv1ConsumerRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private EloquentUiTiDv1ConsumerRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new EloquentUiTiDv1ConsumerRepository();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_save_one_or_more_consumers(): void
+    {
+        $integrationId = Uuid::uuid4();
+
+        $consumer1 = new UiTiDv1Consumer(
+            $integrationId,
+            'consumer-key-1',
+            'consumer-secret-1',
+            'api-key-1',
+            UiTiDv1Environment::Acceptance
+        );
+        $consumer2 = new UiTiDv1Consumer(
+            $integrationId,
+            'consumer-key-2',
+            'consumer-secret-2',
+            'api-key-2',
+            UiTiDv1Environment::Testing
+        );
+        $consumer3 = new UiTiDv1Consumer(
+            $integrationId,
+            'consumer-key-3',
+            'consumer-secret-3',
+            'api-key-3',
+            UiTiDv1Environment::Production
+        );
+
+        $this->repository->save($consumer1, $consumer2, $consumer3);
+
+        $this->assertDatabaseHas('uitidv1_consumers', [
+            'integration_id' => $integrationId->toString(),
+            'consumer_key' => 'consumer-key-1',
+            'consumer_secret' => 'consumer-secret-1',
+            'api_key' => 'api-key-1',
+            'environment' => 'acc',
+        ]);
+        $this->assertDatabaseHas('uitidv1_consumers', [
+            'integration_id' => $integrationId->toString(),
+            'consumer_key' => 'consumer-key-2',
+            'consumer_secret' => 'consumer-secret-2',
+            'api_key' => 'api-key-2',
+            'environment' => 'test',
+        ]);
+        $this->assertDatabaseHas('uitidv1_consumers', [
+            'integration_id' => $integrationId->toString(),
+            'consumer_key' => 'consumer-key-3',
+            'consumer_secret' => 'consumer-secret-3',
+            'api_key' => 'api-key-3',
+            'environment' => 'prod',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_all_consumers_for_an_integration_id(): void
+    {
+        $integrationId = Uuid::uuid4();
+
+        $consumer1 = new UiTiDv1Consumer(
+            $integrationId,
+            'consumer-key-1',
+            'consumer-secret-1',
+            'api-key-1',
+            UiTiDv1Environment::Acceptance
+        );
+        $consumer2 = new UiTiDv1Consumer(
+            $integrationId,
+            'consumer-key-2',
+            'consumer-secret-2',
+            'api-key-2',
+            UiTiDv1Environment::Testing
+        );
+        $consumer3 = new UiTiDv1Consumer(
+            $integrationId,
+            'consumer-key-3',
+            'consumer-secret-3',
+            'api-key-3',
+            UiTiDv1Environment::Production
+        );
+
+        $this->repository->save($consumer1, $consumer2, $consumer3);
+
+        $expected = [$consumer1, $consumer2, $consumer3];
+        $actual = $this->repository->getByIntegrationId($integrationId);
+
+        sort($expected);
+        sort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
### Added

- Added event listener for `IntegrationCreated` that creates a consumer in every configured UiTiD v1 environment (acc/test/prod).

### Changed

- `Auth0ClusterSDK::createClientsForIntegration()` returns an `array` instead of `Collection`, because the only place where it was used I had to do an explicit `->toArray()` to get rid of a warning in PHPStorm. And since that means the only place that calls it expects an `array`, it makes more sense to just return that imho. (Noticed this while working on the UiTiD v1 equivalent.)

---
Ticket: https://jira.uitdatabank.be/browse/PPF-102
