### PR TITLE
PPF-66 Add SSO support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,7 +67,7 @@ AUTH0_LOGIN_DOMAIN=account-acc.uitid.be
 AUTH0_LOGIN_CLIENT_ID=
 AUTH0_LOGIN_CLIENT_SECRET=
 AUTH0_LOGIN_REDIRECT_URI=http://localhost/auth/callback
-AUTH0_LOGIN_PARAMETERS="locale=nl&referrer=publiq-platform&prompt=login&skip_verify_legacy=true&product_display_name=publiq platform"
+AUTH0_LOGIN_PARAMETERS="locale=nl&referrer=publiq-platform&skip_verify_legacy=true&product_display_name=publiq platform"
 
 # MUST always be set to DEV tenant config except for the .env for the production app!
 # Otherwise local/staging/acceptance/testing environments of publiq platform will create real clients on acc/test/prod.

--- a/app/Domain/Auth/Controllers/Logout.php
+++ b/app/Domain/Auth/Controllers/Logout.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Auth\Controllers;
 
+use Auth0\Laravel\Auth0;
 use Auth0\Laravel\Contract\Auth\Guard;
 use Illuminate\Contracts\Auth\Factory;
 use Illuminate\Http\JsonResponse;
@@ -32,8 +33,13 @@ final class Logout
             Auth::guard(config('nova.guard'))->logout();
         }
 
+        $auth0LogoutLink = app(Auth0::class)
+            ->getSdk()
+            ->authentication()
+            ->getLogoutLink(config('app.url'));
+
         return new JsonResponse([
-            'redirect' => config('auth0.routes.home', '/'),
+            'redirect' => $auth0LogoutLink,
         ]);
     }
 }


### PR DESCRIPTION
### Added

- Added SSO support with uitinvlaanderen.be and uitpas.be (among others). To try it out, log in on https://acc.uitinvlaanderen.be and then go to http://localhost/admin. You will be logged in automatically. Note that if you go to http://localhost instead you won't be logged in automatically as the login flow is not triggered then. But if you go to http://localhost/integrations or http://localhost/integrations/create you should also be logged in automatically because those pages require a login. This behavior is consistent with the SSO behaviour on https://www.uitinvlaanderen.be and https://www.uitpas.be where you also need to explicitly click on the "user" icon or login button before the SSO is triggered. Important ⚠️ You MUST remove the `prompt=login` from the Auth0 login parameters in your `.env` file if you have that configured, otherwise the SSO won't work as every login flow will force the login screen to be shown even if you are already logged in on Auth0 via another website.

### Changed

- When logging out, you will also be redirected to Auth0 and logged out there (this is invisible to the end user). If we didn't do this you would automatically be logged in again as the same user as before when logging in again, because you'd still be logged in on Auth0 and the SSO behaviour would make you log in again as that user. This makes the `prompt=login` parameter unnecessary.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-66
