### PR TITLE
PPF-110 ContactType readonly

### DIFF
--- a/app/Nova/Resources/Contact.php
+++ b/app/Nova/Resources/Contact.php
@@ -49,6 +49,7 @@ final class Contact extends Resource
                     ContactType::Technical->value => ContactType::Technical->name,
                     ContactType::Contributor->value => ContactType::Contributor->name,
                 ])
+                ->readonly(fn (NovaRequest $request) => $request->isUpdateOrUpdateAttachedRequest())
                 ->rules('required'),
 
             Text::make('First Name', 'first_name')


### PR DESCRIPTION
### Changed
- The ContactType field on a contact can not be changed during a contact update anymore

---
Ticket: https://jira.uitdatabank.be/browse/PPF-110
