### PR TITLE
Remove usage of http_build_query

### DIFF
--- a/app/Insightly/Resources/InsightlyContactResource.php
+++ b/app/Insightly/Resources/InsightlyContactResource.php
@@ -62,17 +62,9 @@ final class InsightlyContactResource implements ContactResource
      */
     public function findIdsByEmail(string $email): array
     {
-        $query = http_build_query(
-            [
-                'field_name' => 'email_address',
-                'field_value' => $email,
-                'brief' => true,
-            ]
-        );
-
         $request = new Request(
             'GET',
-            $this->path . "Search?$query"
+            $this->path . "Search/?field_name=EMAIL_ADDRESS&field_value=$email&brief=true"
         );
 
         $response = $this->insightlyClient->sendRequest($request);


### PR DESCRIPTION
### Fixed
- Removed usage of  http_build_query because using http_build_query will do a URL encode on the email address, resulting in a bad request. 
