### PR TITLE
PPF-129 Integration field on contact update read-only

### DIFF
--- a/app/Nova/Resources/Contact.php
+++ b/app/Nova/Resources/Contact.php
@@ -67,6 +67,7 @@ final class Contact extends Resource
 
             BelongsTo::make('Integration')
                 ->withoutTrashed()
+                ->readonly(fn (NovaRequest $request) => $request->isUpdateOrUpdateAttachedRequest())
                 ->rules('required'),
 
             InsightlyLink::make('Insightly ID', fn () => $this->insightlyId())


### PR DESCRIPTION
### Changed
- The integration field of a contact can no longer be updated. It's a read-only field.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-129
