### PR TITLE
Add `get` method on `ContactResource`

### DIFF
--- a/app/Insightly/Resources/ContactResource.php
+++ b/app/Insightly/Resources/ContactResource.php
@@ -10,6 +10,8 @@ interface ContactResource
 {
     public function create(Contact $contact): int;
 
+    public function get(int $id): array;
+
     public function update(Contact $contact, int $id): void;
 
     public function delete(int $id): void;

--- a/app/Insightly/Resources/InsightlyContactResource.php
+++ b/app/Insightly/Resources/InsightlyContactResource.php
@@ -35,6 +35,18 @@ final class InsightlyContactResource implements ContactResource
         return $contactAsArray['CONTACT_ID'];
     }
 
+    public function get(int $id): array
+    {
+        $request = new Request(
+            'GET',
+            $this->path . $id
+        );
+
+        $response = $this->insightlyClient->sendRequest($request);
+
+        return Json::decodeAssociatively($response->getBody()->getContents());
+    }
+
     public function update(Contact $contact, int $id): void
     {
         $request = new Request(

--- a/tests/Insightly/Resources/InsightlyContactResourceTest.php
+++ b/tests/Insightly/Resources/InsightlyContactResourceTest.php
@@ -101,6 +101,28 @@ final class InsightlyContactResourceTest extends TestCase
         $this->resource->update($contact, $insightlyId);
     }
 
+    public function test_it_gets_a_contact(): void
+    {
+        $insightlyId = 42;
+        $contact = [
+            'CONTACT_ID' => $insightlyId,
+            'FIRST_NAME' => 'Jane',
+            'LAST_NAME' => 'Doe',
+            'EMAIL_ADDRESS' => 'jane.doe@anonymous.com',
+        ];
+
+        $expectedRequest = new Request('GET', 'Contacts/' . $insightlyId);
+        $expectedResponse = new Response(200, [], Json::encode($contact));
+
+        $this->insightlyClient->expects($this->once())
+            ->method('sendRequest')
+            ->with(self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedRequest, $actualRequest)))
+            ->willReturn($expectedResponse);
+
+        $actualContact = $this->resource->get(42);
+        $this->assertEquals($contact, $actualContact);
+    }
+
     public function test_it_deletes_a_contact(): void
     {
         $expectedRequest = new Request('DELETE', 'Contacts/42');

--- a/tests/Insightly/Resources/InsightlyOpportunityResourceTest.php
+++ b/tests/Insightly/Resources/InsightlyOpportunityResourceTest.php
@@ -146,6 +146,38 @@ final class InsightlyOpportunityResourceTest extends TestCase
         ];
     }
 
+    public function test_it_gets_an_opportunity(): void
+    {
+        $insightlyId = 42;
+        $opportunity = [
+            'OPPORTUNITY_ID' => $insightlyId,
+            'OPPORTUNITY_NAME' => 'my integration',
+            'OPPORTUNITY_STATE' => OpportunityState::OPEN->value,
+            'OPPORTUNITY_DETAILS' => 'description',
+            'PIPELINE_ID' => $this->pipelineId,
+            'STAGE_ID' => $this->testStageId,
+        ];
+
+        $expectedRequest = new Request(
+            'GET',
+            'Opportunities/' . $insightlyId,
+        );
+
+        $expectedResponse = new Response(
+            200,
+            [],
+            Json::encode($opportunity)
+        );
+
+        $this->insightlyClient->expects($this->once())
+            ->method('sendRequest')
+            ->with(self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedRequest, $actualRequest)))
+            ->willReturn($expectedResponse);
+
+        $actualOpportunity = $this->resource->get($insightlyId);
+        $this->assertEquals($opportunity, $actualOpportunity);
+    }
+
     public function test_it_deletes_an_opportunity(): void
     {
         $expectedRequest = new Request('DELETE', 'Opportunities/42');

--- a/tests/Insightly/Resources/InsightlyProjectResourceTest.php
+++ b/tests/Insightly/Resources/InsightlyProjectResourceTest.php
@@ -139,6 +139,38 @@ final class InsightlyProjectResourceTest extends TestCase
         $this->resource->linkOpportunity(42, 31);
     }
 
+    public function test_it_gets_a_project(): void
+    {
+        $insightlyProjectId = 42;
+        $project = [
+            'PROJECT_ID' => $insightlyProjectId,
+            'PROJECT_NAME' => 'my integration',
+            'STATUS' => ProjectState::NOT_STARTED->value,
+            'PROJECT_DETAILS' => 'description',
+            'PIPELINE_ID' => $this->pipelineId,
+            'STAGE_ID' => $this->testStageId,
+        ];
+
+        $expectedRequest = new Request(
+            'GET',
+            'Projects/' . $insightlyProjectId,
+        );
+
+        $expectedResponse = new Response(
+            200,
+            [],
+            Json::encode($project)
+        );
+
+        $this->insightlyClient->expects($this->once())
+            ->method('sendRequest')
+            ->with(self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedRequest, $actualRequest)))
+            ->willReturn($expectedResponse);
+
+        $actualProject = $this->resource->get($insightlyProjectId);
+        $this->assertEquals($project, $actualProject);
+    }
+
     public function test_it_links_a_contact_to_a_project(): void
     {
         $insightlyProjectId = 42;


### PR DESCRIPTION
### Added
- Added `get` method on `ContactResource`
- Added missing test for `get` on `OpportunityResource`
- Added missing test for `get` on `ProjectResource`
- Added missing test `updateWithCoupon` on `ProjectResource`

### Note
- Preparation for migration command
