### PR TITLE
Refactored save contact to either update or create

### DIFF
--- a/app/Domain/Contacts/Repositories/EloquentContactRepository.php
+++ b/app/Domain/Contacts/Repositories/EloquentContactRepository.php
@@ -13,14 +13,19 @@ final class EloquentContactRepository implements ContactRepository
 {
     public function save(Contact $contact): void
     {
-        ContactModel::query()->create([
-            'id' => $contact->id->toString(),
-            'integration_id' => $contact->integrationId->toString(),
-            'type' => $contact->type->value,
-            'first_name' => $contact->firstName,
-            'last_name' => $contact->lastName,
-            'email' => $contact->email,
-        ]);
+        ContactModel::query()->updateOrCreate(
+            [
+                'id' => $contact->id->toString(),
+            ],
+            [
+                'id' => $contact->id->toString(),
+                'integration_id' => $contact->integrationId->toString(),
+                'type' => $contact->type->value,
+                'first_name' => $contact->firstName,
+                'last_name' => $contact->lastName,
+                'email' => $contact->email,
+            ]
+        );
     }
 
     public function getById(UuidInterface $id): Contact

--- a/tests/Domain/Contacts/Repositories/EloquentContactRepositoryTest.php
+++ b/tests/Domain/Contacts/Repositories/EloquentContactRepositoryTest.php
@@ -23,7 +23,7 @@ final class EloquentContactRepositoryTest extends TestCase
         $this->contactRepository = new EloquentContactRepository();
     }
 
-    public function test_it_can_create_a_contact(): void
+    public function test_it_can_create_and_update_a_contact(): void
     {
         $contact = new Contact(
             Uuid::uuid4(),

--- a/tests/Domain/Contacts/Repositories/EloquentContactRepositoryTest.php
+++ b/tests/Domain/Contacts/Repositories/EloquentContactRepositoryTest.php
@@ -23,7 +23,7 @@ final class EloquentContactRepositoryTest extends TestCase
         $this->contactRepository = new EloquentContactRepository();
     }
 
-    public function test_it_can_save_a_contact(): void
+    public function test_it_can_create_a_contact(): void
     {
         $contact = new Contact(
             Uuid::uuid4(),
@@ -33,7 +33,6 @@ final class EloquentContactRepositoryTest extends TestCase
             'Jane',
             'Doe'
         );
-
         $this->contactRepository->save($contact);
 
         $this->assertDatabaseHas('contacts', [
@@ -43,6 +42,25 @@ final class EloquentContactRepositoryTest extends TestCase
             'first_name' => $contact->firstName,
             'last_name' => $contact->lastName,
             'email' => $contact->email,
+        ]);
+
+        $updatedContact = new Contact(
+            $contact->id,
+            Uuid::uuid4(),
+            'john.doedoe@anonymous.com',
+            ContactType::Functional,
+            'John',
+            'DoeDoe'
+        );
+        $this->contactRepository->save($updatedContact);
+
+        $this->assertDatabaseHas('contacts', [
+            'id' => $updatedContact->id->toString(),
+            'integration_id' => $updatedContact->integrationId->toString(),
+            'type' => $updatedContact->type,
+            'first_name' => $updatedContact->firstName,
+            'last_name' => $updatedContact->lastName,
+            'email' => $updatedContact->email,
         ]);
     }
 


### PR DESCRIPTION
### Changed
- Refactored saving a contact with the `ContactRepository` to either update a contact or create a new contact based on the id

### Note
- As preparation for the migration
- In the future more `save` methods will need to be refactored to do a `create` or `update`