### PR TITLE
Use acc UiTiD email address for Corneel as Nova admin

### DIFF
--- a/config/nova.php
+++ b/config/nova.php
@@ -93,7 +93,7 @@ return [
         'dev@publiq.be',
         'simon.debruijn@publiq.be',
         'lucwollants@gmail.com',
-        'corneel@publiq.be',
+        'corneel.wille@publiq.be',
     ],
 
     /*


### PR DESCRIPTION
### Changed
- Used acc UiTiD email address for Corneel as Nova admin
