### PR TITLE
PPF-135 Create auth0 clients for migrated projects

### DIFF
--- a/app/Console/Commands/Migrations/CreateAuth0Clients.php
+++ b/app/Console/Commands/Migrations/CreateAuth0Clients.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Console\Migrations;
+namespace App\Console\Commands\Migrations;
 
 use App\Auth0\Auth0ClusterSDK;
 use App\Auth0\Repositories\Auth0ClientRepository;

--- a/app/Console/Commands/Migrations/MigrateCoupons.php
+++ b/app/Console/Commands/Migrations/MigrateCoupons.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Console\Migrations;
+namespace App\Console\Commands\Migrations;
 
 use App\Domain\Auth\Models\UserModel;
 use App\Domain\Coupons\Coupon;

--- a/app/Console/Commands/Migrations/MigrateProjects.php
+++ b/app/Console/Commands/Migrations/MigrateProjects.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Console\Migrations;
+namespace App\Console\Commands\Migrations;
 
 use App\Domain\Auth\Models\UserModel;
 use App\Domain\Contacts\Contact;

--- a/app/Console/Commands/Migrations/MigrationProject.php
+++ b/app/Console/Commands/Migrations/MigrationProject.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Console\Migrations;
+namespace App\Console\Commands\Migrations;
 
 use App\Domain\Integrations\IntegrationStatus;
 use App\Domain\Integrations\IntegrationType;

--- a/app/Console/Commands/Migrations/ReadCsvFile.php
+++ b/app/Console/Commands/Migrations/ReadCsvFile.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Console\Migrations;
+namespace App\Console\Commands\Migrations;
 
 trait ReadCsvFile
 {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,18 +4,11 @@ declare(strict_types=1);
 
 namespace App\Console;
 
-use App\Console\Migrations\MigrateCoupons;
-use App\Console\Migrations\MigrateProjects;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
 final class Kernel extends ConsoleKernel
 {
-    protected $commands = [
-        MigrateCoupons::class,
-        MigrateProjects::class,
-    ];
-
     protected function schedule(Schedule $schedule): void
     {
     }

--- a/app/Console/Migrations/CreateAuth0Clients.php
+++ b/app/Console/Migrations/CreateAuth0Clients.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Migrations;
+
+use App\Auth0\Auth0ClusterSDK;
+use App\Auth0\Repositories\Auth0ClientRepository;
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\Models\IntegrationModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+final class CreateAuth0Clients extends Command
+{
+    protected $signature = 'auth0:create-auth0-clients';
+
+    protected $description = 'Create Auth0 clients for migrated integrations';
+
+    public function __construct(
+        private readonly Auth0ClusterSDK $auth0ClusterSDK,
+        private readonly Auth0ClientRepository $auth0ClientRepository
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $migratedIntegrations = $this->getMigratedIntegrations();
+
+        $migratedIntegrationsCount = count($migratedIntegrations);
+        if ($migratedIntegrationsCount <= 0) {
+            $this->warn('No migrated integrations found');
+            return 0;
+        }
+
+        if (!$this->confirm('Are you sure you want to create Auth0 clients for ' . $migratedIntegrationsCount . ' integrations?')) {
+            return 0;
+        }
+
+        foreach ($migratedIntegrations as $migratedIntegration) {
+            $this->info($migratedIntegration->id . ' - Started creating Auth0 Clients');
+
+            $this->createAuth0ClientsForIntegration($migratedIntegration);
+
+            $this->info($migratedIntegration->id . ' - Finished creating Auth0 Clients');
+            $this->info('---');
+        }
+
+        return 1;
+    }
+
+    private function createAuth0ClientsForIntegration(Integration $integration): void
+    {
+        $auth0Clients = $this->auth0ClientRepository->getByIntegrationId($integration->id);
+
+        if (count($auth0Clients) > 0) {
+            $this->warn($integration->id . ' - already has Auth0 clients');
+            return;
+        }
+
+        $auth0Clients = $this->auth0ClusterSDK->createClientsForIntegration($integration);
+        $this->auth0ClientRepository->save(...$auth0Clients);
+    }
+
+    /**
+     * @return Collection<Integration>
+     */
+    private function getMigratedIntegrations(): Collection
+    {
+        $migratedIntegrationModels = IntegrationModel::query()->whereNotNull('migrated_at')->get();
+        $migratedIntegrations = new Collection();
+
+        foreach ($migratedIntegrationModels as $migratedIntegrationModel) {
+            $migratedIntegrations->add($migratedIntegrationModel->toDomain());
+        }
+
+        return $migratedIntegrations;
+    }
+}


### PR DESCRIPTION
### Added
- Created command `CreateAuth0Clients` to create Auth0 clients for migrated integrations. If no saved Auth0 clients are found new ones are created on all environments.

---

Ticket: https://jira.uitdatabank.be/browse/PPF-135
