### PR TITLE
Add command to create missing UiTiD v1 consumers

### DIFF
--- a/app/Console/Commands/Migrations/CreateMissingUiTiDv1Consumers.php
+++ b/app/Console/Commands/Migrations/CreateMissingUiTiDv1Consumers.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Migrations;
+
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\Models\IntegrationModel;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1ClusterSDK;
+use App\UiTiDv1\UiTiDv1Consumer;
+use App\UiTiDv1\UiTiDv1Environment;
+use App\UiTiDv1\UiTiDv1EnvironmentNotConfigured;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+final class CreateMissingUiTiDv1Consumers extends Command
+{
+    protected $signature = 'uitidv1:create-missing-uitidv1-consumers';
+
+    protected $description = 'Create UiTiD v1 consumers(s) for integrations that are missing one or more';
+
+    public function __construct(
+        private readonly UiTiDv1ClusterSDK $uiTiDv1ClusterSDK,
+        private readonly UiTiDv1ConsumerRepository $uiTiDv1ConsumerRepository
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $integrations = $this->getIntegrationsWithMissingUiTiDv1Consumers();
+
+        $integrationsCount = count($integrations);
+        if ($integrationsCount <= 0) {
+            $this->warn('No integrations with missing UiTiD v1 Consumers found');
+            return 0;
+        }
+
+        if (!$this->confirm('Are you sure you want to create UiTiD v1 Consumers for ' . $integrationsCount . ' integrations?')) {
+            return 0;
+        }
+
+        foreach ($integrations as $integration) {
+            $this->info($integration->id . ' - Started creating UiTiD v1 Consumers');
+
+            $this->createMissingUiTiDConsumerForIntegration($integration);
+
+            $this->info($integration->id . ' - Finished creating UiTiD v1 Consumers');
+            $this->info('---');
+        }
+
+        return 1;
+    }
+
+    private function createMissingUiTiDConsumerForIntegration(Integration $integration): void
+    {
+        $uiTiDv1Consumers = $this->uiTiDv1ConsumerRepository->getByIntegrationId($integration->id);
+
+        $existingEnvironments = array_map(
+            static fn (UiTiDv1Consumer $uiTiDv1Consumer) => $uiTiDv1Consumer->environment,
+            $uiTiDv1Consumers
+        );
+        $missingEnvironments = array_udiff(
+            UiTiDv1Environment::cases(),
+            $existingEnvironments,
+            fn (UiTiDv1Environment $e1, UiTiDv1Environment $e2) => strcmp($e1->value, $e2->value)
+        );
+
+        foreach ($missingEnvironments as $missingEnvironment) {
+            try {
+                $uitidv1Consumer = $this->uiTiDv1ClusterSDK->createConsumerForIntegrationOnEnvironment(
+                    $integration,
+                    $missingEnvironment
+                );
+                $this->uiTiDv1ConsumerRepository->save($uitidv1Consumer);
+
+                $this->info($integration->id . ' - created UiTiD v1 Consumer on ' . $missingEnvironment->value);
+            } catch (UiTiDv1EnvironmentNotConfigured) {
+                $this->warn($integration->id . ' - missing config for UiTiD v1 environment ' . $missingEnvironment->value);
+            }
+        }
+    }
+
+    /**
+     * @return Collection<Integration>
+     */
+    private function getIntegrationsWithMissingUiTiDv1Consumers(): Collection
+    {
+        $integrationModels = IntegrationModel::query()->has(
+            'uiTiDv1Consumers',
+            '<',
+            count(UiTiDv1Environment::cases())
+        )->get();
+
+        $integrations = new Collection();
+
+        foreach ($integrationModels as $integrationModel) {
+            $integrations->add($integrationModel->toDomain());
+        }
+
+        return $integrations;
+    }
+}

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -15,6 +15,7 @@ use App\Domain\Integrations\IntegrationType;
 use App\Domain\Subscriptions\Models\SubscriptionModel;
 use App\Insightly\Models\InsightlyMappingModel;
 use App\Models\UuidModel;
+use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -111,6 +112,14 @@ final class IntegrationModel extends UuidModel
     public function auth0Clients(): HasMany
     {
         return $this->hasMany(Auth0ClientModel::class, 'integration_id');
+    }
+
+    /**
+     * @return HasMany<UiTiDv1ConsumerModel>
+     */
+    public function uiTiDv1Consumers(): HasMany
+    {
+        return $this->hasMany(UiTiDv1ConsumerModel::class, 'integration_id');
     }
 
     public function toDomain(): Integration

--- a/app/UiTiDv1/UiTiDv1ClusterSDK.php
+++ b/app/UiTiDv1/UiTiDv1ClusterSDK.php
@@ -32,4 +32,18 @@ final class UiTiDv1ClusterSDK
             )
         );
     }
+
+    /**
+     * @throws UiTiDv1EnvironmentNotConfigured
+     */
+    public function createConsumerForIntegrationOnEnvironment(
+        Integration $integration,
+        UiTiDv1Environment $environment
+    ): UiTiDv1Consumer {
+        if (!key_exists($environment->value, $this->uitidv1EnvironmentSDKs)) {
+            throw new UiTiDv1EnvironmentNotConfigured($environment);
+        }
+
+        return $this->uitidv1EnvironmentSDKs[$environment->value]->createConsumerForIntegration($integration);
+    }
 }

--- a/app/UiTiDv1/UiTiDv1EnvironmentNotConfigured.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentNotConfigured.php
@@ -6,7 +6,7 @@ namespace App\UiTiDv1;
 
 use Exception;
 
-class UiTiDv1EnvironmentNotConfigured extends Exception
+final class UiTiDv1EnvironmentNotConfigured extends Exception
 {
     public function __construct(UiTiDv1Environment $uiTiDv1Environment)
     {

--- a/app/UiTiDv1/UiTiDv1EnvironmentNotConfigured.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentNotConfigured.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1;
+
+use Exception;
+
+class UiTiDv1EnvironmentNotConfigured extends Exception
+{
+    public function __construct(UiTiDv1Environment $uiTiDv1Environment)
+    {
+        parent::__construct('No configuration found for UiTiD v1 environment ' . $uiTiDv1Environment->value);
+    }
+}


### PR DESCRIPTION
### Added
- Added command `CreateMissingUiTiDv1Consumers` to create missing UiTiD v1 Consumers

---
Ticket: https://jira.uitdatabank.be/browse/PPF-136
