### PR TITLE
PPF-97 Activate integration with organization (Laravel Nova part)

### DIFF
--- a/app/Domain/Integrations/Events/IntegrationActivatedWithOrganization.php
+++ b/app/Domain/Integrations/Events/IntegrationActivatedWithOrganization.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Ramsey\Uuid\UuidInterface;
+
+final class IntegrationActivatedWithOrganization
+{
+    use Dispatchable;
+
+    public function __construct(public readonly UuidInterface $id)
+    {
+    }
+}

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -54,7 +54,7 @@ final class IntegrationModel extends UuidModel
         return parent::delete();
     }
 
-    public function activeWithCoupon(): void
+    public function activateWithCoupon(): void
     {
         $this->update([
             'status' => IntegrationStatus::Active,
@@ -62,7 +62,7 @@ final class IntegrationModel extends UuidModel
         IntegrationActivatedWithCoupon::dispatch(Uuid::fromString($this->id));
     }
 
-    public function activeWithOrganization(UuidInterface $organizationId): void
+    public function activateWithOrganization(UuidInterface $organizationId): void
     {
         $this->update([
             'organization_id' => $organizationId->toString(),

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -75,6 +75,14 @@ final class IntegrationModel extends UuidModel
     }
 
     /**
+     * @return BelongsTo<OrganizationModel, IntegrationModel>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationModel::class, 'organization_id');
+    }
+
+    /**
      * @return HasMany<InsightlyMappingModel>
      */
     public function insightlyMappings(): HasMany

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -7,11 +7,13 @@ namespace App\Domain\Integrations\Models;
 use App\Auth0\Models\Auth0ClientModel;
 use App\Domain\Contacts\Models\ContactModel;
 use App\Domain\Coupons\Models\CouponModel;
+use App\Domain\Integrations\Events\IntegrationActivatedWithOrganization;
 use App\Domain\Integrations\Events\IntegrationActivatedWithCoupon;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\IntegrationStatus;
 use App\Domain\Integrations\IntegrationType;
+use App\Domain\Organizations\Models\OrganizationModel;
 use App\Domain\Subscriptions\Models\SubscriptionModel;
 use App\Insightly\Models\InsightlyMappingModel;
 use App\Models\UuidModel;
@@ -21,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 final class IntegrationModel extends UuidModel
 {
@@ -56,6 +59,15 @@ final class IntegrationModel extends UuidModel
             'status' => IntegrationStatus::Active,
         ]);
         IntegrationActivatedWithCoupon::dispatch(Uuid::fromString($this->id));
+    }
+
+    public function activeWithOrganization(UuidInterface $organizationId): void
+    {
+        $this->update([
+            'organization_id' => $organizationId->toString(),
+            'status' => IntegrationStatus::Active,
+        ]);
+        IntegrationActivatedWithOrganization::dispatch(Uuid::fromString($this->id));
     }
 
     /**

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -37,6 +37,7 @@ final class IntegrationModel extends UuidModel
         'name',
         'description',
         'subscription_id',
+        'organization_id',
         'status',
     ];
 

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -88,7 +88,7 @@ final class EloquentIntegrationRepository implements IntegrationRepository
 
             /** @var IntegrationModel $integrationModel */
             $integrationModel = IntegrationModel::query()->findOrFail($id->toString());
-            $integrationModel->activeWithCoupon();
+            $integrationModel->activateWithCoupon();
         });
     }
 
@@ -96,6 +96,6 @@ final class EloquentIntegrationRepository implements IntegrationRepository
     {
         /** @var IntegrationModel $integrationModel */
         $integrationModel = IntegrationModel::query()->findOrFail($id->toString());
-        $integrationModel->activeWithOrganization($organizationId);
+        $integrationModel->activateWithOrganization($organizationId);
     }
 }

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -78,21 +78,24 @@ final class EloquentIntegrationRepository implements IntegrationRepository
 
     public function activateWithCouponCode(UuidInterface $id, string $couponCode): void
     {
-        $integration = $this->getById($id);
-
-        DB::transaction(static function () use ($couponCode, $integration): void {
+        DB::transaction(static function () use ($couponCode, $id): void {
             /** @var CouponModel $couponModel */
             $couponModel = CouponModel::query()
                 ->where('code', '=', $couponCode)
                 ->whereNull('integration_id')
                 ->firstOrFail();
-            $couponModel->useOnIntegration($integration->id);
+            $couponModel->useOnIntegration($id);
 
             /** @var IntegrationModel $integrationModel */
-            $integrationModel = IntegrationModel::query()
-                ->where('id', '=', $integration->id)
-                ->firstOrFail();
+            $integrationModel = IntegrationModel::query()->findOrFail($id->toString());
             $integrationModel->activeWithCoupon();
         });
+    }
+
+    public function activateWithOrganization(UuidInterface $id, UuidInterface $organizationId): void
+    {
+        /** @var IntegrationModel $integrationModel */
+        $integrationModel = IntegrationModel::query()->findOrFail($id->toString());
+        $integrationModel->activeWithOrganization($organizationId);
     }
 }

--- a/app/Domain/Integrations/Repositories/IntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/IntegrationRepository.php
@@ -15,4 +15,5 @@ interface IntegrationRepository
     public function deleteById(UuidInterface $id): ?bool;
     public function getByContactEmail(string $email): Collection;
     public function activateWithCouponCode(UuidInterface $id, string $couponCode): void;
+    public function activateWithOrganization(UuidInterface $id, UuidInterface $organizationId): void;
 }

--- a/app/Insightly/Listeners/CreateProjectWithCoupon.php
+++ b/app/Insightly/Listeners/CreateProjectWithCoupon.php
@@ -20,6 +20,7 @@ use App\Insightly\SyncIsAllowed;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 final class CreateProjectWithCoupon implements ShouldQueue
 {
@@ -99,7 +100,7 @@ final class CreateProjectWithCoupon implements ShouldQueue
         }
 
         $this->logger->info(
-            'Project created for integration activated with coupon',
+            'Project created for integration with coupon',
             [
                 'domain' => 'insightly',
                 'integration_id' => $integrationActivatedWithCoupon->id->toString(),
@@ -107,10 +108,12 @@ final class CreateProjectWithCoupon implements ShouldQueue
         );
     }
 
-    public function failed(IntegrationActivatedWithCoupon $integrationActivatedWithCoupon, \Throwable $exception): void
-    {
+    public function failed(
+        IntegrationActivatedWithCoupon $integrationActivatedWithCoupon,
+        Throwable $exception
+    ): void {
         $this->logger->error(
-            'Failed to activate integration',
+            'Failed create project for integration with coupon',
             [
                 'domain' => 'insightly',
                 'contact_id' => $integrationActivatedWithCoupon->id->toString(),

--- a/app/Nova/Actions/ActivateIntegrationWithCoupon.php
+++ b/app/Nova/Actions/ActivateIntegrationWithCoupon.php
@@ -16,7 +16,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Ramsey\Uuid\Uuid;
 
-final class ActivateIntegration extends Action
+final class ActivateIntegrationWithCoupon extends Action
 {
     use InteractsWithQueue;
     use Queueable;

--- a/app/Nova/Actions/ActivateIntegrationWithCoupon.php
+++ b/app/Nova/Actions/ActivateIntegrationWithCoupon.php
@@ -35,7 +35,7 @@ final class ActivateIntegrationWithCoupon extends Action
             $integration = $integrations->first();
             $this->repository->activateWithCouponCode(Uuid::fromString($integration->id), $couponCode);
 
-            return Action::message('Integration ' . $integration->name . ' activated with coupon ' . $fields->get('coupon'));
+            return Action::message('Integration ' . $integration->name . ' activated with coupon ' . $couponCode);
         } catch (ModelNotFoundException $exception) {
             return Action::danger($couponCode . ' is not an valid coupon.');
         }

--- a/app/Nova/Actions/ActivateIntegrationWithOrganization.php
+++ b/app/Nova/Actions/ActivateIntegrationWithOrganization.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions;
+
+use App\Domain\Integrations\Models\IntegrationModel;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\Domain\Organizations\Models\OrganizationModel;
+use App\Domain\Organizations\Repositories\OrganizationRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Ramsey\Uuid\Uuid;
+
+final class ActivateIntegrationWithOrganization extends Action
+{
+    use InteractsWithQueue;
+    use Queueable;
+
+    public function __construct(
+        public readonly IntegrationRepository $integrationRepository,
+        public readonly OrganizationRepository $organizationRepository
+    ) {
+    }
+
+    public function handle(ActionFields $fields, Collection $integrations): array
+    {
+        /** @var string $organizationIdAsString */
+        $organizationIdAsString = $fields->get('organization');
+        $organizationId = Uuid::fromString($organizationIdAsString);
+
+        $organization = $this->organizationRepository->getById($organizationId);
+
+        /** @var IntegrationModel $integration */
+        $integration = $integrations->first();
+        $this->integrationRepository->activateWithOrganization(
+            Uuid::fromString($integration->id),
+            $organizationId
+        );
+
+        return Action::message(
+            'Integration ' . $integration->name . ' activated with organization ' . $organization->name
+        );
+    }
+
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            Select::make('Organization', 'organization')->options(
+                OrganizationModel::query()->pluck('name', 'id')
+            ),
+        ];
+    }
+}

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -109,6 +109,11 @@ final class Integration extends Resource
                 ->withoutTrashed()
                 ->rules('required'),
 
+            BelongsTo::make('Organization')
+                ->withoutTrashed()
+                ->hideFromIndex()
+                ->nullable(),
+
             DateTime::make('Created', 'created_at')
                 ->readonly()
                 ->onlyOnIndex()

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -184,9 +184,9 @@ final class Integration extends Resource
         $integrationModel = $this->model();
 
         return [
-            (new ActivateIntegration(App::make(IntegrationRepository::class)))
+            (new ActivateIntegrationWithCoupon(App::make(IntegrationRepository::class)))
                 ->onlyOnTableRow($integrationModel->status === IntegrationStatus::Draft->value)
-                ->confirmText('Are you sure you want to activate this integration?')
+                ->confirmText('Are you sure you want to activate this integration with a coupon?')
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate"),
         ];

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -9,7 +9,9 @@ use App\Domain\Integrations\IntegrationStatus;
 use App\Domain\Integrations\IntegrationType;
 use App\Domain\Integrations\Models\IntegrationModel;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
-use App\Nova\Actions\ActivateIntegration;
+use App\Domain\Organizations\Repositories\OrganizationRepository;
+use App\Nova\Actions\ActivateIntegrationWithOrganization;
+use App\Nova\Actions\ActivateIntegrationWithCoupon;
 use App\Nova\Resource;
 use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
 use Illuminate\Support\Facades\App;
@@ -188,10 +190,25 @@ final class Integration extends Resource
         /** @var IntegrationModel $integrationModel */
         $integrationModel = $this->model();
 
+        if ($integrationModel->status !== IntegrationStatus::Draft->value) {
+            return [];
+        }
+
         return [
             (new ActivateIntegrationWithCoupon(App::make(IntegrationRepository::class)))
-                ->onlyOnTableRow($integrationModel->status === IntegrationStatus::Draft->value)
+                ->showOnDetail()
+                ->showInline()
                 ->confirmText('Are you sure you want to activate this integration with a coupon?')
+                ->confirmButtonText('Activate')
+                ->cancelButtonText("Don't activate"),
+
+            (new ActivateIntegrationWithOrganization(
+                App::make(IntegrationRepository::class),
+                App::make(OrganizationRepository::class)
+            ))
+                ->showOnDetail()
+                ->showInline()
+                ->confirmText('Are you sure you want to activate this integration with an organization?')
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate"),
         ];

--- a/database/migrations/2023_02_15_141921_add_organization_id_to_integrations_table.php
+++ b/database/migrations/2023_02_15_141921_add_organization_id_to_integrations_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('integrations', function (Blueprint $table) {
+            $table->uuid('organization_id')->after('subscription_id')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('integrations', function (Blueprint $table) {
+            $table->dropColumn('organization_id');
+        });
+    }
+};

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -327,4 +327,34 @@ final class EloquentIntegrationRepositoryTest extends TestCase
         $this->expectException(ModelNotFoundException::class);
         $this->integrationRepository->activateWithCouponCode($integrationId, $couponCode);
     }
+
+    public function test_it_can_active_with_an_organization(): void
+    {
+        $integrationId = Uuid::uuid4();
+        $organizationId = Uuid::uuid4();
+
+        $searchIntegration = new Integration(
+            $integrationId,
+            IntegrationType::SearchApi,
+            'Search Integration',
+            'Search Integration description',
+            Uuid::uuid4(),
+            IntegrationStatus::Draft,
+            [],
+        );
+
+        $this->integrationRepository->save($searchIntegration);
+
+        $this->integrationRepository->activateWithOrganization($integrationId, $organizationId);
+
+        $this->assertDatabaseHas('integrations', [
+            'id' => $searchIntegration->id->toString(),
+            'type' => $searchIntegration->type,
+            'name' => $searchIntegration->name,
+            'description' => $searchIntegration->description,
+            'subscription_id' => $searchIntegration->subscriptionId,
+            'organization_id' => $organizationId,
+            'status' => IntegrationStatus::Active,
+        ]);
+    }
 }


### PR DESCRIPTION
### Added
- Made it possible to activate an integration with an organization in Laravel Nova
- Added `organization_id` column on `integrations` table to store `BelongsTo` relation
- Made it possible to select an organization in the integration edit form

### Fixed
- Fixed issue with enabling of activate action

### Note
- In Laravel Nova we can require that the organization needs to be created first
- The sync to Insightly will be implemented in a follow-up pull request

---
Ticket: https://jira.uitdatabank.be/browse/PPF-97
