### PR TITLE
Remove withConsecutive calls in tests

### DIFF
--- a/tests/AssertRequest.php
+++ b/tests/AssertRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 
 trait AssertRequest
 {
@@ -15,5 +16,20 @@ trait AssertRequest
         self::assertEquals($expected->getBody()->getContents(), $actual->getBody()->getContents());
 
         return true;
+    }
+
+    private static function assertRequestResponseWithCallback(
+        Request $firstRequest,
+        Response $firstResponse,
+        Request $secondRequest,
+        Response $secondResponse,
+    ): callable
+    {
+        return fn (Request $actualRequest) =>
+            match ([$actualRequest->getHeaders(), $actualRequest->getMethod(), $actualRequest->getBody()->getContents()]) {
+                [$firstRequest->getHeaders(), $firstRequest->getMethod(), $firstRequest->getBody()->getContents()] => $firstResponse,
+                [$secondRequest->getHeaders(), $secondRequest->getMethod(), $secondRequest->getBody()->getContents()] => $secondResponse,
+                default => throw new \LogicException('Invalid arguments received'),
+            };
     }
 }

--- a/tests/Insightly/Listeners/CreateProjectWithCouponTest.php
+++ b/tests/Insightly/Listeners/CreateProjectWithCouponTest.php
@@ -145,9 +145,12 @@ final class CreateProjectWithCouponTest extends TestCase
         // It links the contacts
         $this->projectResource->expects($this->exactly(2))
             ->method('linkContact')
-            ->withConsecutive(
-                [$insightlyProjectId, $insightlyTechnicalId],
-                [$insightlyProjectId, $insightlyFunctionalId],
+            ->willReturnCallback(
+                fn (int $actualInsightlyProjectId, int $actualInsightlyContactId, ContactType $actualContactType) =>
+                    match ([$actualInsightlyProjectId, $actualInsightlyContactId, $actualContactType]) {
+                        [$insightlyProjectId, $insightlyTechnicalId, ContactType::Technical],
+                        [$insightlyProjectId, $insightlyFunctionalId, ContactType::Functional] => null,
+                    }
             );
 
         // When
@@ -200,15 +203,13 @@ final class CreateProjectWithCouponTest extends TestCase
 
         $this->insightlyMappingRepository->expects($this->exactly(3))
             ->method('getByIdAndType')
-            ->withConsecutive(
-                [$this->integrationId, ResourceType::Opportunity],
-                [$this->technicalContactId, ResourceType::Contact],
-                [$this->functionalContactId, ResourceType::Contact],
-            )
-            ->willReturnOnConsecutiveCalls(
-                $insightlyIntegrationMapping,
-                $insightlyTechnicalContactMapping,
-                $insightlyFunctionalContactMapping,
+            ->willReturnCallback(
+                fn (UuidInterface $actualIntegrationId, ResourceType $actualResourceType) =>
+                    match ([$actualIntegrationId, $actualResourceType]) {
+                        [$this->integrationId, ResourceType::Opportunity] => $insightlyIntegrationMapping,
+                        [$this->technicalContactId, ResourceType::Contact] => $insightlyTechnicalContactMapping,
+                        [$this->functionalContactId, ResourceType::Contact] => $insightlyFunctionalContactMapping,
+                    }
             );
     }
 

--- a/tests/Insightly/Listeners/CreateProjectWithCouponTest.php
+++ b/tests/Insightly/Listeners/CreateProjectWithCouponTest.php
@@ -150,6 +150,7 @@ final class CreateProjectWithCouponTest extends TestCase
                     match ([$actualInsightlyProjectId, $actualInsightlyContactId, $actualContactType]) {
                         [$insightlyProjectId, $insightlyTechnicalId, ContactType::Technical],
                         [$insightlyProjectId, $insightlyFunctionalId, ContactType::Functional] => null,
+                        default => throw new \LogicException('Invalid arguments received'),
                     }
             );
 
@@ -209,6 +210,7 @@ final class CreateProjectWithCouponTest extends TestCase
                         [$this->integrationId, ResourceType::Opportunity] => $insightlyIntegrationMapping,
                         [$this->technicalContactId, ResourceType::Contact] => $insightlyTechnicalContactMapping,
                         [$this->functionalContactId, ResourceType::Contact] => $insightlyFunctionalContactMapping,
+                        default => throw new \LogicException('Invalid arguments received'),
                     }
             );
     }

--- a/tests/Insightly/Listeners/SyncContactTest.php
+++ b/tests/Insightly/Listeners/SyncContactTest.php
@@ -327,13 +327,13 @@ final class SyncContactTest extends TestCase
 
         $this->insightlyMappingRepository
             ->method('getByIdAndType')
-            ->withConsecutive(
-                [$this->integrationId, ResourceType::Opportunity],
-                [$this->integrationId, ResourceType::Project],
-            )
-            ->willReturnOnConsecutiveCalls(
-                $mappedToOpportunity ? $insightlyOpportunityMapping : $this->throwException(new ModelNotFoundException()),
-                $mappedToProject ? $insightlyProjectMapping : $this->throwException(new ModelNotFoundException()),
+            ->willReturnCallback(
+                fn (UuidInterface $actualIntegrationId, ResourceType $actualResourceType) =>
+                    match ([$actualIntegrationId, $actualResourceType]) {
+                        [$this->integrationId, ResourceType::Opportunity] => $mappedToOpportunity ? $insightlyOpportunityMapping : throw new ModelNotFoundException(),
+                        [$this->integrationId, ResourceType::Project] => $mappedToProject ? $insightlyProjectMapping : throw new ModelNotFoundException(),
+                        default => throw new \LogicException('Invalid arguments received'),
+                    }
             );
     }
 

--- a/tests/Insightly/Listeners/UnlinkContactTest.php
+++ b/tests/Insightly/Listeners/UnlinkContactTest.php
@@ -141,12 +141,11 @@ final class UnlinkContactTest extends TestCase
             ResourceType::Opportunity,
         );
 
-        $this->insightlyMappingRepository->expects(self::exactly(2))
+        $this->insightlyMappingRepository
             ->method('getByIdAndType')
-            ->withConsecutive(
-                [$this->contactId, ResourceType::Contact],
-                [$this->integrationId, ResourceType::Opportunity]
-            )
-            ->willReturn($insightlyContactMapping, $insightlyOpportunityMapping);
+            ->will($this->returnValueMap([
+                [$this->contactId, ResourceType::Contact, $insightlyContactMapping],
+                [$this->integrationId, ResourceType::Opportunity, $insightlyOpportunityMapping],
+            ]));
     }
 }

--- a/tests/Insightly/Resources/InsightlyProjectResourceTest.php
+++ b/tests/Insightly/Resources/InsightlyProjectResourceTest.php
@@ -155,13 +155,13 @@ final class InsightlyProjectResourceTest extends TestCase
 
         $this->insightlyClient->expects($this->exactly(2))
             ->method('sendRequest')
-            ->withConsecutive(
-                [self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedGetRequest, $actualRequest))],
-                [self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedPutRequest, $actualRequest))]
-            )
-            ->willReturnOnConsecutiveCalls(
-                new Response(200, [], Json::encode($project)),
-                new Response()
+            ->willReturnCallback(
+                fn (Request $actualRequest) =>
+                    match ([$actualRequest->getHeaders(), $actualRequest->getMethod(), $actualRequest->getBody()->getContents()]) {
+                        [$expectedGetRequest->getHeaders(), $expectedGetRequest->getMethod(), $expectedGetRequest->getBody()->getContents()] => new Response(200, [], Json::encode($project)),
+                        [$expectedPutRequest->getHeaders(), $expectedPutRequest->getMethod(), $expectedPutRequest->getBody()->getContents()] => new Response(),
+                        default => throw new \LogicException('Invalid arguments received'),
+                    }
             );
 
         $this->resource->updateWithCoupon(42, $couponCode);
@@ -302,13 +302,13 @@ final class InsightlyProjectResourceTest extends TestCase
 
         $this->insightlyClient->expects($this->exactly(2))
             ->method('sendRequest')
-            ->withConsecutive(
-                [self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedLinksGetRequest, $actualRequest))],
-                [self::callback(fn ($actualRequest): bool => self::assertRequestIsTheSame($expectedDeleteLinkRequest, $actualRequest))],
-            )
-            ->willReturnOnConsecutiveCalls(
-                new Response(200, [], Json::encode($projectLinks)),
-                new Response(202)
+            ->willReturnCallback(
+                fn (Request $actualRequest) =>
+                    match ([$actualRequest->getHeaders(), $actualRequest->getMethod(), $actualRequest->getBody()->getContents()]) {
+                        [$expectedLinksGetRequest->getHeaders(), $expectedLinksGetRequest->getMethod(), $expectedLinksGetRequest->getBody()->getContents()] => new Response(200, [], Json::encode($projectLinks)),
+                        [$expectedDeleteLinkRequest->getHeaders(), $expectedDeleteLinkRequest->getMethod(), $expectedDeleteLinkRequest->getBody()->getContents()] => new Response(202),
+                        default => throw new \LogicException('Invalid arguments received'),
+                    }
             );
 
         $this->resource->unlinkContact($projectId, $contactId);

--- a/tests/UiTiDv1/Listeners/CreateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/CreateConsumersTest.php
@@ -69,39 +69,37 @@ final class CreateConsumersTest extends TestCase
 
         $this->httpClient->expects($this->exactly(3))
             ->method('request')
-            ->withConsecutive(
-                [
-                    'POST',
-                    'serviceconsumer',
-                    [
-                        'http_errors' => false,
-                        'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                        'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=1&group=2',
-                    ],
-                ],
-                [
-                    'POST',
-                    'serviceconsumer',
-                    [
-                        'http_errors' => false,
-                        'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                        'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=7&group=8',
-                    ],
-                ],
-                [
-                    'POST',
-                    'serviceconsumer',
-                    [
-                        'http_errors' => false,
-                        'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                        'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=13&group=14',
-                    ],
-                ]
-            )
-            ->willReturnOnConsecutiveCalls(
-                new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer1.xml')),
-                new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer2.xml')),
-                new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer3.xml')),
+            ->willReturnCallback(
+                fn (string $actualMethod, string $actualUri, array $actualOptions) =>
+                    match ([$actualMethod, $actualUri, $actualOptions]) {
+                        [
+                            'POST',
+                            'serviceconsumer',
+                            [
+                                'http_errors' => false,
+                                'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                                'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=1&group=2',
+                            ],
+                        ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer1.xml')),
+                        [
+                            'POST',
+                            'serviceconsumer',
+                            [
+                                'http_errors' => false,
+                                'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                                'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=7&group=8',
+                            ],
+                        ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer2.xml')),
+                        [
+                            'POST',
+                            'serviceconsumer',
+                            [
+                                'http_errors' => false,
+                                'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                                'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=13&group=14',
+                            ],
+                        ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer3.xml'))
+                    }
             );
 
         $expectedConsumers = [

--- a/tests/UiTiDv1/Listeners/CreateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/CreateConsumersTest.php
@@ -98,7 +98,8 @@ final class CreateConsumersTest extends TestCase
                                 'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
                                 'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description&group=13&group=14',
                             ],
-                        ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer3.xml'))
+                        ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer3.xml')),
+                        default => throw new \LogicException('Invalid arguments received'),
                     }
             );
 


### PR DESCRIPTION
### Removed
- All calls to  `MockObject::withConsecutive` have been replaced with `willReturnCallback` to make them compliant with phpunit10.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-148
