### PR TITLE
PPF-173 Update UiTiD v1 consumers when integration is updated

### DIFF
--- a/app/UiTiDv1/Listeners/UpdateConsumers.php
+++ b/app/UiTiDv1/Listeners/UpdateConsumers.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1\Listeners;
+
+use App\Domain\Integrations\Events\IntegrationUpdated;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1ClusterSDK;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+final class UpdateConsumers implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly UiTiDv1ClusterSDK $clusterSDK,
+        private readonly UiTiDv1ConsumerRepository $consumerRepository,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function handle(IntegrationUpdated $integrationUpdated): void
+    {
+        $integration = $this->integrationRepository->getById($integrationUpdated->id);
+        $consumers = $this->consumerRepository->getByIntegrationId($integrationUpdated->id);
+
+        $this->clusterSDK->updateConsumersForIntegration($integration, ...$consumers);
+
+        $this->logger->info(
+            'UiTiD v1 consumer(s) updated',
+            [
+                'domain' => 'uitid',
+                'integration_id' => $integrationUpdated->id->toString(),
+            ]
+        );
+    }
+
+    public function failed(IntegrationUpdated $integrationUpdated, Throwable $throwable): void
+    {
+        $this->logger->error('Failed to update UiTiD v1 consumer(s)', [
+            'integration_id' => $integrationUpdated->id->toString(),
+            'exception' => $throwable,
+        ]);
+    }
+}

--- a/app/UiTiDv1/UiTiDv1ClusterSDK.php
+++ b/app/UiTiDv1/UiTiDv1ClusterSDK.php
@@ -33,6 +33,16 @@ final class UiTiDv1ClusterSDK
         );
     }
 
+    public function updateConsumersForIntegration(Integration $integration, UiTiDv1Consumer ...$uiTiDv1Consumers): void
+    {
+        foreach ($uiTiDv1Consumers as $uiTiDv1Consumer) {
+            $this->uitidv1EnvironmentSDKs[$uiTiDv1Consumer->environment->value]->updateConsumerForIntegration(
+                $integration,
+                $uiTiDv1Consumer
+            );
+        }
+    }
+
     /**
      * @throws UiTiDv1EnvironmentNotConfigured
      */

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -51,6 +51,16 @@ final class UiTiDv1EnvironmentSDK
         );
     }
 
+    public function updateConsumerForIntegration(Integration $integration, UiTiDv1Consumer $consumer): void
+    {
+        $formData = [
+            'name' => $this->consumerName($integration),
+            'description' => $integration->description,
+        ];
+
+        $this->sendPostRequest('serviceconsumer/' . $consumer->consumerKey, $formData);
+    }
+
     public function blockConsumer(UiTiDv1Consumer $consumer): void
     {
         $formData = [

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -24,10 +24,8 @@ final class UiTiDv1EnvironmentSDK
 
     public function createConsumerForIntegration(Integration $integration): UiTiDv1Consumer
     {
-        $name = sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
-
         $formData = [
-            'name' => $name,
+            'name' => $this->consumerName($integration),
             'description' => $integration->description,
             'group' => $this->permissionGroupsPerIntegrationType[$integration->type->value] ?? [],
         ];
@@ -106,5 +104,10 @@ final class UiTiDv1EnvironmentSDK
         }
 
         return $response;
+    }
+
+    private function consumerName(Integration $integration): string
+    {
+        return sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
     }
 }

--- a/app/UiTiDv1/UiTiDv1ServiceProvider.php
+++ b/app/UiTiDv1/UiTiDv1ServiceProvider.php
@@ -6,8 +6,10 @@ namespace App\UiTiDv1;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
+use App\Domain\Integrations\Events\IntegrationUpdated;
 use App\UiTiDv1\Listeners\BlockConsumers;
 use App\UiTiDv1\Listeners\CreateConsumers;
+use App\UiTiDv1\Listeners\UpdateConsumers;
 use App\UiTiDv1\Repositories\EloquentUiTiDv1ConsumerRepository;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
 use Illuminate\Support\Facades\Event;
@@ -58,6 +60,7 @@ final class UiTiDv1ServiceProvider extends ServiceProvider
             // May always be registered even if there are no configured environments, because in that case the cluster SDK
             // will just not have any environment SDKs to loop over and so it simply won't do anything. But it won't crash either.
             Event::listen(IntegrationCreated::class, [CreateConsumers::class, 'handle']);
+            Event::listen(IntegrationUpdated::class, [UpdateConsumers::class, 'handle']);
             Event::listen(IntegrationBlocked::class, [BlockConsumers::class, 'handle']);
         }
     }

--- a/tests/UiTiDv1/Listeners/BlockConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/BlockConsumersTest.php
@@ -111,7 +111,6 @@ final class BlockConsumersTest extends TestCase
                 }
             );
 
-
         $this->blockConsumers->handle(new IntegrationBlocked($integrationId));
     }
 }

--- a/tests/UiTiDv1/Listeners/UpdateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/UpdateConsumersTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UiTiDv1\Listeners;
+
+use App\Domain\Integrations\Events\IntegrationUpdated;
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationStatus;
+use App\Domain\Integrations\IntegrationType;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\UiTiDv1\Listeners\UpdateConsumers;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1Consumer;
+use App\UiTiDv1\UiTiDv1Environment;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
+
+final class UpdateConsumersTest extends TestCase
+{
+    use CreatesMockUiTiDv1ClusterSDK;
+
+    private ClientInterface&MockObject $httpClient;
+
+    private UiTiDv1ConsumerRepository&MockObject $consumerRepository;
+
+    private IntegrationRepository&MockObject $integrationRepository;
+
+    private UpdateConsumers $updateConsumers;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->consumerRepository = $this->createMock(UiTiDv1ConsumerRepository::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
+
+        $this->updateConsumers = new UpdateConsumers(
+            $this->createMockUiTiDv1ClusterSDK($this->httpClient),
+            $this->consumerRepository,
+            $this->integrationRepository,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    public function test_it_updates_consumers(): void
+    {
+        $integrationId = Uuid::uuid4();
+
+        $integration = new Integration(
+            $integrationId,
+            IntegrationType::EntryApi,
+            'Mock Integration',
+            'Mock description',
+            Uuid::uuid4(),
+            IntegrationStatus::Draft,
+            []
+        );
+
+        $consumers = [
+            new UiTiDv1Consumer(
+                $integrationId,
+                '4135',
+                'mock-consumer-key-1',
+                'mock-consumer-secret-1',
+                'mock-api-key-1',
+                UiTiDv1Environment::Acceptance
+            ),
+            new UiTiDv1Consumer(
+                $integrationId,
+                '4136',
+                'mock-consumer-key-2',
+                'mock-consumer-secret-2',
+                'mock-api-key-2',
+                UiTiDv1Environment::Testing
+            ),
+            new UiTiDv1Consumer(
+                $integrationId,
+                '4137',
+                'mock-consumer-key-3',
+                'mock-consumer-secret-3',
+                'mock-api-key-3',
+                UiTiDv1Environment::Production
+            ),
+        ];
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with($integrationId)
+            ->willReturn($integration);
+
+        $this->consumerRepository->expects($this->once())
+            ->method('getByIntegrationId')
+            ->with($integrationId)
+            ->willReturn($consumers);
+
+        $this->httpClient->expects($this->exactly(3))
+            ->method('request')
+            ->willReturnCallback(
+                fn (string $actualMethod, string $actualUri, array $actualOptions) =>
+                match ([$actualMethod, $actualUri, $actualOptions]) {
+                    [
+                        'POST',
+                        'serviceconsumer/mock-consumer-key-1',
+                        [
+                            'http_errors' => false,
+                            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                            'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description',
+                        ],
+                    ],
+                    [
+                        'POST',
+                        'serviceconsumer/mock-consumer-key-2',
+                        [
+                            'http_errors' => false,
+                            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                            'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description',
+                        ],
+                    ],
+                    [
+                        'POST',
+                        'serviceconsumer/mock-consumer-key-3',
+                        [
+                            'http_errors' => false,
+                            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                            'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&description=Mock%20description',
+                        ],
+                    ] => new Response(200, [], ''),
+                    default => throw new \LogicException('Invalid arguments received'),
+                }
+            );
+
+        $this->updateConsumers->handle(new IntegrationUpdated($integrationId));
+    }
+}


### PR DESCRIPTION
### Changed
- Add listener `UpdateConsumers` which is bound to `IntegrationUpdated` and will update the name and description of the consumer according to the updated integration.

### Note
- The name could be changed depending on the outcome of https://jira.uitdatabank.be/browse/PPF-168

---
Ticket: https://jira.uitdatabank.be/browse/PPF-173
