### PR TITLE
PPF-172 Update name of Auth0 client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ stan:
 test:
 	vendor/bin/sail composer test
 
+test-filter:
+	vendor/bin/sail composer test -- --filter=$(filter)
+
 test-insightly:
 	vendor/bin/sail composer test tests/Insightly/InsightlyClientTest.php
 

--- a/README.md
+++ b/README.md
@@ -224,3 +224,13 @@ $ make stan
 ```
 $ make test
 ```
+
+- Run a test with filtered on file
+```
+$ make test-filter filter=UpdateClientsTest
+```
+
+- Run a test with a filtered on test method name
+```
+$ make test-filter filter=test_it_can_get_an_organization_with_vat
+```

--- a/app/Auth0/Auth0ClusterSDK.php
+++ b/app/Auth0/Auth0ClusterSDK.php
@@ -33,6 +33,13 @@ final class Auth0ClusterSDK
         );
     }
 
+    public function updateClientsForIntegration(Integration $integration, Auth0Client ...$auth0Clients): void
+    {
+        foreach ($auth0Clients as $auth0Client) {
+            $this->auth0TenantSDKs[$auth0Client->tenant->value]->updateClient($integration, $auth0Client);
+        }
+    }
+
     /**
      * @throws Auth0TenantNotConfigured
      */

--- a/app/Auth0/Auth0ServiceProvider.php
+++ b/app/Auth0/Auth0ServiceProvider.php
@@ -6,10 +6,12 @@ namespace App\Auth0;
 
 use App\Auth0\Listeners\BlockClients;
 use App\Auth0\Listeners\CreateClients;
+use App\Auth0\Listeners\UpdateClients;
 use App\Auth0\Repositories\Auth0ClientRepository;
 use App\Auth0\Repositories\EloquentAuth0ClientRepository;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
+use App\Domain\Integrations\Events\IntegrationUpdated;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
@@ -63,6 +65,7 @@ final class Auth0ServiceProvider extends ServiceProvider
             // May always be registered even if there are no configured tenants, because in that case the cluster SDK will
             // just not have any tenant SDKs to loop over and so it simply won't do anything. But it won't crash either.
             Event::listen(IntegrationCreated::class, [CreateClients::class, 'handle']);
+            Event::listen(IntegrationUpdated::class, [UpdateClients::class, 'handle']);
             Event::listen(IntegrationBlocked::class, [BlockClients::class, 'handle']);
         }
     }

--- a/app/Auth0/Auth0TenantSDK.php
+++ b/app/Auth0/Auth0TenantSDK.php
@@ -88,6 +88,26 @@ final class Auth0TenantSDK
         return new Auth0Client($integration->id, $clientId, $clientSecret, $this->auth0Tenant);
     }
 
+    public function updateClient(Integration $integration, Auth0Client $auth0Client): void
+    {
+        try {
+            $this->updateClientGuarded($integration, $auth0Client);
+        } catch (Auth0Unauthorized) {
+            $this->initToken($this->sdkConfiguration);
+            $this->updateClientGuarded($integration, $auth0Client);
+        }
+    }
+
+    private function updateClientGuarded(Integration $integration, Auth0Client $auth0Client): void
+    {
+        $clientResponse = $this->management->clients()->update(
+            $auth0Client->clientId,
+            ['name' => $this->clientName($integration)]
+        );
+
+        $this->guardResponseStatus(200, $clientResponse);
+    }
+
     public function blockClient(Auth0Client $auth0Client): void
     {
         try {

--- a/app/Auth0/Auth0TenantSDK.php
+++ b/app/Auth0/Auth0TenantSDK.php
@@ -35,15 +35,13 @@ final class Auth0TenantSDK
 
     private function createClientForIntegrationGuarded(Integration $integration): Auth0Client
     {
-        $name = sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
-
         $apis = match ($integration->type) {
             IntegrationType::SearchApi, IntegrationType::Widgets => 'sapi',
             IntegrationType::EntryApi => 'entry sapi',
         };
 
         $clientResponse = $this->management->clients()->create(
-            $name,
+            $this->clientName($integration),
             [
                 'app_type' => 'regular_web', // The app type has no real meaning/implications, but regular_web is the most logical for generic clients for integrators
                 'client_metadata' => [
@@ -139,5 +137,10 @@ final class Auth0TenantSDK
         $response = $auth0->authentication()->clientCredentials($sdkConfiguration->getAudience());
         $data = Json::decodeAssociatively((string) $response->getBody());
         $auth0->configuration()->setManagementToken($data['access_token']);
+    }
+
+    private function clientName(Integration $integration): string
+    {
+        return sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
     }
 }

--- a/app/Auth0/Listeners/UpdateClients.php
+++ b/app/Auth0/Listeners/UpdateClients.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth0\Listeners;
+
+use App\Auth0\Auth0ClusterSDK;
+use App\Auth0\Repositories\Auth0ClientRepository;
+use App\Domain\Integrations\Events\IntegrationUpdated;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+final class UpdateClients implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly Auth0ClusterSDK $clusterSDK,
+        private readonly Auth0ClientRepository $auth0ClientRepository,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function handle(IntegrationUpdated $integrationUpdated): void
+    {
+        $integration = $this->integrationRepository->getById($integrationUpdated->id);
+        $auth0Clients = $this->auth0ClientRepository->getByIntegrationId($integrationUpdated->id);
+
+        $this->clusterSDK->updateClientsForIntegration($integration, ...$auth0Clients);
+
+        $this->logger->info(
+            'Auth0 client(s) updated',
+            [
+                'domain' => 'auth0',
+                'integration_id' => $integrationUpdated->id->toString(),
+            ]
+        );
+    }
+
+    public function failed(IntegrationUpdated $integrationBlocked, Throwable $throwable): void
+    {
+        $this->logger->error('Failed to update Auth0 client(s)', [
+            'integration_id' => $integrationBlocked->id->toString(),
+            'exception' => $throwable,
+        ]);
+    }
+}


### PR DESCRIPTION
### Changed
- Add listener `UpdateClients` which is bound to `IntegrationUpdated` and will update the name of the client according to the updated integration.

### Note
- The name could be changed depending on the outcome of https://jira.uitdatabank.be/browse/PPF-168

---
Ticket: https://jira.uitdatabank.be/browse/PPF-172
