### PR TITLE
PPF-153 Configure auth0 client urls in Laravel Nova

### DIFF
--- a/app/Domain/Integrations/Environment.php
+++ b/app/Domain/Integrations/Environment.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations;
+
+enum Environment: string
+{
+    case Acceptance = 'acc';
+    case Testing = 'test';
+    case Production = 'prod';
+}

--- a/app/Domain/Integrations/IntegrationUrl.php
+++ b/app/Domain/Integrations/IntegrationUrl.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations;
+
+use Ramsey\Uuid\UuidInterface;
+
+final class IntegrationUrl
+{
+    public function __construct(
+        public readonly UuidInterface $integrationId,
+        public readonly Environment $environment,
+        public readonly IntegrationUrlType $type,
+        public readonly string $url
+    ) {
+    }
+}

--- a/app/Domain/Integrations/IntegrationUrlType.php
+++ b/app/Domain/Integrations/IntegrationUrlType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations;
+
+enum IntegrationUrlType: string
+{
+    case Login = 'login';
+    case Callback = 'callback';
+    case Logout = 'logout';
+}

--- a/app/Domain/Integrations/IntegrationUrlType.php
+++ b/app/Domain/Integrations/IntegrationUrlType.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Domain\Integrations;
 
+/**
+ * More information about the different URLs can be found inside the Auth0 docs
+ * @see https://auth0.com/docs/get-started/applications/application-settings#application-uris
+ */
 enum IntegrationUrlType: string
 {
     case Login = 'login';

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -121,6 +121,14 @@ final class IntegrationModel extends UuidModel
         return $this->hasMany(InsightlyMappingModel::class, 'id');
     }
 
+    /**
+     * @return HasMany<IntegrationUrlModel>
+     */
+    public function urls(): HasMany
+    {
+        return $this->hasMany(IntegrationUrlModel::class, 'integration_id');
+    }
+
     public function insightlyOpportunityId(): ?string
     {
         return $this->insightlyMappings()

--- a/app/Domain/Integrations/Models/IntegrationUrlModel.php
+++ b/app/Domain/Integrations/Models/IntegrationUrlModel.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Models;
+
+use App\Domain\Integrations\Environment;
+use App\Domain\Integrations\IntegrationUrl;
+use App\Domain\Integrations\IntegrationUrlType;
+use App\Models\UuidModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Ramsey\Uuid\Uuid;
+
+final class IntegrationUrlModel extends UuidModel
+{
+    protected $table = 'integrations_urls';
+
+    protected $fillable = [
+        'integration_id',
+        'environment',
+        'type',
+        'url',
+    ];
+
+    /**
+     * @return BelongsTo<IntegrationModel, IntegrationUrlModel>
+     */
+    public function integration(): BelongsTo
+    {
+        return $this->belongsTo(IntegrationModel::class, 'integration_id');
+    }
+
+    public function toDomain(): IntegrationUrl
+    {
+        return new IntegrationUrl(
+            Uuid::fromString($this->integration_id),
+            Environment::from($this->environment),
+            IntegrationUrlType::from($this->type),
+            $this->url
+        );
+    }
+}

--- a/app/Domain/Integrations/Policies/IntegrationUrlPolicy.php
+++ b/app/Domain/Integrations/Policies/IntegrationUrlPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Policies;
+
+use App\Domain\Auth\Models\UserModel;
+use App\Domain\Integrations\Models\IntegrationUrlModel;
+
+final class IntegrationUrlPolicy
+{
+    public function viewAny(UserModel $userModel): bool
+    {
+        return true;
+    }
+
+    public function view(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
+    {
+        return true;
+    }
+
+    public function create(UserModel $userModel): bool
+    {
+        return true;
+    }
+
+    public function update(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
+    {
+        return true;
+    }
+
+    public function delete(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
+    {
+        return true;
+    }
+
+    public function restore(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
+    {
+        return false;
+    }
+
+    public function replicate(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
+    {
+        return false;
+    }
+
+    public function forceDelete(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
+    {
+        return false;
+    }
+}

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -187,6 +187,8 @@ final class Integration extends Resource
 
             HasMany::make('Contacts'),
 
+            HasMany::make('Urls', 'urls', IntegrationUrl::class),
+
             HasMany::make('Activity Log'),
         ];
     }

--- a/app/Nova/Resources/IntegrationUrl.php
+++ b/app/Nova/Resources/IntegrationUrl.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Resources;
+
+use App\Domain\Integrations\Environment;
+use App\Domain\Integrations\IntegrationUrlType;
+use App\Domain\Integrations\Models\IntegrationUrlModel;
+use App\Nova\Resource;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+final class IntegrationUrl extends Resource
+{
+    public static string $model = IntegrationUrlModel::class;
+
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            BelongsTo::make('Integration')
+                ->withoutTrashed()
+                ->sortable(),
+
+            Select::make('Environment')
+                ->filterable()
+                ->sortable()
+                ->options([
+                    Environment::Acceptance->value => Environment::Acceptance->name,
+                    Environment::Testing->value => Environment::Testing->name,
+                    Environment::Production->value => Environment::Production->name,
+                ])
+                ->rules('required'),
+
+            Select::make('Type')
+                ->filterable()
+                ->sortable()
+                ->options([
+                    IntegrationUrlType::Login->value => IntegrationUrlType::Login->name,
+                    IntegrationUrlType::Callback->value => IntegrationUrlType::Callback->name,
+                    IntegrationUrlType::Logout->value => IntegrationUrlType::Logout->name,
+                ])
+                ->rules('required'),
+
+            Text::make('Url')
+                ->sortable()
+                ->rules('required', 'url'),
+        ];
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -11,7 +11,9 @@ use App\Domain\Contacts\Policies\ContactPolicy;
 use App\Domain\Coupons\Models\CouponModel;
 use App\Domain\Coupons\Policies\CouponPolicy;
 use App\Domain\Integrations\Models\IntegrationModel;
+use App\Domain\Integrations\Models\IntegrationUrlModel;
 use App\Domain\Integrations\Policies\IntegrationPolicy;
+use App\Domain\Integrations\Policies\IntegrationUrlPolicy;
 use App\Domain\Organizations\Models\OrganizationModel;
 use App\Domain\Organizations\Policies\OrganizationPolicy;
 use App\Domain\Subscriptions\Models\SubscriptionModel;
@@ -26,6 +28,7 @@ final class AuthServiceProvider extends ServiceProvider
         ContactModel::class => ContactPolicy::class,
         CouponModel::class => CouponPolicy::class,
         IntegrationModel::class => IntegrationPolicy::class,
+        IntegrationUrlModel::class => IntegrationUrlPolicy::class,
         OrganizationModel::class => OrganizationPolicy::class,
         SubscriptionModel::class => SubscriptionPolicy::class,
     ];

--- a/database/migrations/2023_03_20_155932_create_integrations_urls_table.php
+++ b/database/migrations/2023_03_20_155932_create_integrations_urls_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('integrations_urls', static function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('integration_id')->index();
+            $table->string('environment');
+            $table->string('type');
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('integrations_urls');
+    }
+};


### PR DESCRIPTION
### Added
- Implemented a Laravel Nova resource to link URLs with a specific environment (acceptance/test/production) and a specific type (login/logout/callback) to an integration

### Note
- This PR only focuses on introducing the new Laravel Nova resource `IntegrationUrl`
- In a follow-up PR the upload to Auth0 and combined validation rules will be implemented

---
Ticket: https://jira.uitdatabank.be/browse/PPF-153
