### PR TITLE
PP-168 Replace Auth0 client and UiTiD consumer name suffix

### DIFF
--- a/app/Auth0/Auth0TenantSDK.php
+++ b/app/Auth0/Auth0TenantSDK.php
@@ -162,7 +162,7 @@ final class Auth0TenantSDK
 
     private function clientName(Integration $integration): string
     {
-        return sprintf('%s (via publiq platform)', $integration->name);
+        return $integration->name . ' (via publiq platform)';
     }
 
     private function getLoginUrl(Integration $integration): string

--- a/app/Auth0/Auth0TenantSDK.php
+++ b/app/Auth0/Auth0TenantSDK.php
@@ -151,6 +151,6 @@ final class Auth0TenantSDK
 
     private function clientName(Integration $integration): string
     {
-        return sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
+        return sprintf('%s (via publiq platform)', $integration->name);
     }
 }

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -116,6 +116,6 @@ final class UiTiDv1EnvironmentSDK
 
     private function consumerName(Integration $integration): string
     {
-        return sprintf('%s (via publiq platform)', $integration->name);
+        return $integration->name . ' (via publiq platform)';
     }
 }

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -116,6 +116,6 @@ final class UiTiDv1EnvironmentSDK
 
     private function consumerName(Integration $integration): string
     {
-        return sprintf('%s (id: %s)', $integration->name, $integration->id->toString());
+        return sprintf('%s (via publiq platform)', $integration->name);
     }
 }

--- a/tests/Auth0/Listeners/UpdateClientsTest.php
+++ b/tests/Auth0/Listeners/UpdateClientsTest.php
@@ -91,17 +91,17 @@ final class UpdateClientsTest extends TestCase
                     [
                         'PATCH',
                         '/api/v2/clients/client-id-1',
-                        Json::encode(['name' => 'Mock Integration (id: ' . $integrationId->toString() . ')']),
+                        Json::encode(['name' => 'Mock Integration (via publiq platform)']),
                     ],
                     [
                         'PATCH',
                         '/api/v2/clients/client-id-2',
-                        Json::encode(['name' => 'Mock Integration (id: ' . $integrationId->toString() . ')']),
+                        Json::encode(['name' => 'Mock Integration (via publiq platform)']),
                     ],
                     [
                         'PATCH',
                         '/api/v2/clients/client-id-3',
-                        Json::encode(['name' => 'Mock Integration (id: ' . $integrationId->toString() . ')']),
+                        Json::encode(['name' => 'Mock Integration (via publiq platform)']),
                     ] => new Response(200, [], ''),
                     default => throw new \LogicException('Invalid arguments received'),
                 }

--- a/tests/UiTiDv1/Listeners/CreateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/CreateConsumersTest.php
@@ -78,7 +78,7 @@ final class CreateConsumersTest extends TestCase
                             [
                                 'http_errors' => false,
                                 'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                                'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&group=1&group=2',
+                                'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29&group=1&group=2',
                             ],
                         ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer1.xml')),
                         [
@@ -87,7 +87,7 @@ final class CreateConsumersTest extends TestCase
                             [
                                 'http_errors' => false,
                                 'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                                'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&group=7&group=8',
+                                'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29&group=7&group=8',
                             ],
                         ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer2.xml')),
                         [
@@ -96,7 +96,7 @@ final class CreateConsumersTest extends TestCase
                             [
                                 'http_errors' => false,
                                 'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                                'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29&group=13&group=14',
+                                'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29&group=13&group=14',
                             ],
                         ] => new Response(200, [], (string) file_get_contents(__DIR__ . '/consumer3.xml')),
                         default => throw new \LogicException('Invalid arguments received'),

--- a/tests/UiTiDv1/Listeners/UpdateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/UpdateConsumersTest.php
@@ -109,7 +109,7 @@ final class UpdateConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29',
+                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29',
                         ],
                     ],
                     [
@@ -118,7 +118,7 @@ final class UpdateConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29',
+                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29',
                         ],
                     ],
                     [
@@ -127,7 +127,7 @@ final class UpdateConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'name=Mock%20Integration%20%28id%3A%20' . $integrationId . '%29',
+                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29',
                         ],
                     ] => new Response(200, [], ''),
                     default => throw new \LogicException('Invalid arguments received'),


### PR DESCRIPTION
### Changed
- Replaced Auth0 client name suffix
- Replaced UiTiD consumer name suffix

---
Ticket: https://jira.uitdatabank.be/browse/PP-168
