### PR TITLE
Fix docker setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run --rm \
     -u "$(id -u):$(id -g)" \
     -v $(pwd):/var/www/html \
     -w /var/www/html \
-    laravelsail/php81-composer:latest \
+    laravelsail/php82-composer:latest \
     composer install
 ```
 


### PR DESCRIPTION
### Fixed
- [Set php docker version to 8.2 instead of 8.1](https://github.com/cultuurnet/publiq-platform/commit/0111d12458d3cb6f0b5164899281e1ce8d6a95d6)
