### PR TITLE
PPF-167 - Fix translated route name causing duplicate route names

### DIFF
--- a/app/Domain/Integrations/Controllers/IntegrationController.php
+++ b/app/Domain/Integrations/Controllers/IntegrationController.php
@@ -24,8 +24,8 @@ final class IntegrationController extends Controller
 {
     public function __construct(
         private readonly SubscriptionRepository $subscriptionRepository,
-        private readonly IntegrationRepository  $integrationRepository,
-        private readonly CurrentUser            $currentUser
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly CurrentUser $currentUser
     ) {
     }
 

--- a/app/Domain/Integrations/Controllers/IntegrationController.php
+++ b/app/Domain/Integrations/Controllers/IntegrationController.php
@@ -88,10 +88,8 @@ final class IntegrationController extends Controller
 
         $this->integrationRepository->save($integration);
 
-        $language = $storeIntegration->headers->get('Accept-Language') ?? 'en';
-
         return Redirect::route(
-            TranslatedRoute::getTranslatedRouteName('integrations.index', $language)
+            TranslatedRoute::getTranslatedRouteName(request: $storeIntegration, routeName: 'integrations.index')
         );
     }
 }

--- a/app/Domain/Integrations/Controllers/IntegrationController.php
+++ b/app/Domain/Integrations/Controllers/IntegrationController.php
@@ -88,7 +88,7 @@ final class IntegrationController extends Controller
 
         $this->integrationRepository->save($integration);
 
-        $language = $storeIntegration->headers->get('Accept-Language');
+        $language = $storeIntegration->headers->get('Accept-Language') ?? 'en';
 
         return Redirect::route(
             TranslatedRoute::getTranslatedRouteName('integrations.index', $language)

--- a/app/Domain/Integrations/Controllers/IntegrationController.php
+++ b/app/Domain/Integrations/Controllers/IntegrationController.php
@@ -13,6 +13,7 @@ use App\Domain\Integrations\IntegrationType;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Domain\Subscriptions\Repositories\SubscriptionRepository;
 use App\Http\Controllers\Controller;
+use App\Router\TranslatedRoute;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
@@ -24,7 +25,7 @@ final class IntegrationController extends Controller
     public function __construct(
         private readonly SubscriptionRepository $subscriptionRepository,
         private readonly IntegrationRepository  $integrationRepository,
-        private readonly CurrentUser $currentUser
+        private readonly CurrentUser            $currentUser
     ) {
     }
 
@@ -87,6 +88,10 @@ final class IntegrationController extends Controller
 
         $this->integrationRepository->save($integration);
 
-        return Redirect::route('integrations.index');
+        $language = $storeIntegration->headers->get('Accept-Language');
+
+        return Redirect::route(
+            TranslatedRoute::getTranslatedRouteName('integrations.index', $language)
+        );
     }
 }

--- a/app/Router/TranslatedRoute.php
+++ b/app/Router/TranslatedRoute.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace App\Router;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 final class TranslatedRoute
 {
-    public static function getTranslatedRouteName(string $routeName, string $language): string
+    public const DEFAULT_LANGUAGE = 'en';
+
+    private static function createTranslatedRouteName(string $routeName, string $language): string
     {
         return implode('.', [$language, $routeName]);
+    }
+
+    public static function getTranslatedRouteName(Request $request, string $routeName): string
+    {
+        $language = $request->headers->get('Accept-Language') ?? self::DEFAULT_LANGUAGE;
+
+        return self::createTranslatedRouteName($routeName, $language);
     }
 
     public static function get(array $languageToUri, \Closure|array|string|null $action = null, ?string $routeName = null): void
@@ -19,7 +29,7 @@ final class TranslatedRoute
             $route = Route::get($uri, $action);
 
             if ($routeName !== null) {
-                $route->name(self::getTranslatedRouteName($routeName, $language));
+                $route->name(self::createTranslatedRouteName($routeName, $language));
             }
         }
     }

--- a/app/Router/TranslatedRoute.php
+++ b/app/Router/TranslatedRoute.php
@@ -8,13 +8,18 @@ use Illuminate\Support\Facades\Route;
 
 final class TranslatedRoute
 {
-    public static function get(array $uris, \Closure|array|string|null $action = null, ?string $routeName = null): void
+    public static function getTranslatedRouteName(string $routeName, string $language): string
     {
-        foreach ($uris as $uri) {
+        return implode('.', [$language, $routeName]);
+    }
+
+    public static function get(array $languageToUri, \Closure|array|string|null $action = null, ?string $routeName = null): void
+    {
+        foreach ($languageToUri as $language => $uri) {
             $route = Route::get($uri, $action);
 
             if ($routeName !== null) {
-                $route->name($routeName);
+                $route->name(self::getTranslatedRouteName($routeName, $language));
             }
         }
     }

--- a/app/Router/TranslatedRoute.php
+++ b/app/Router/TranslatedRoute.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Route;
 
 final class TranslatedRoute
 {
-    public const DEFAULT_LANGUAGE = 'en';
+    public const DEFAULT_LANGUAGE = 'nl';
 
     private static function createTranslatedRouteName(string $routeName, string $language): string
     {

--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -1,7 +1,7 @@
 {
   "pages": {
     "/integrations": "/integraties",
-    "/integrations/create": "/integraties/nieuw",
+    "/integrations/new": "/integraties/nieuw",
     "/support": "/ondersteuning",
     "/subscriptions": "/abonnementen",
     "/login": "/aanmelden",

--- a/resources/translations/nl.json
+++ b/resources/translations/nl.json
@@ -1,7 +1,7 @@
 {
   "pages": {
     "/integrations": "/integraties",
-    "/integrations/create": "/integraties/nieuw",
+    "/integrations/new": "/integraties/nieuw",
     "/support": "/ondersteuning",
     "/subscriptions": "/abonnementen"
   },

--- a/resources/ts/Pages/Integrations/Create.tsx
+++ b/resources/ts/Pages/Integrations/Create.tsx
@@ -28,7 +28,11 @@ const Index = ({ integrationTypes, subscriptions }: Props) => {
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    post("/integrations");
+    post("/integrations", {
+      headers: {
+        "Accept-Language": "nl",
+      },
+    });
   }
 
   return (

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,11 +32,11 @@ Route::post('/admin/logout', Logout::class);
 
 Route::get('/auth/callback', Callback::class);
 
-TranslatedRoute::get(['/subscriptions', '/abonnementen'], [SubscriptionController::class, 'index']);
+TranslatedRoute::get(['en' => '/subscriptions', 'nl' => '/abonnementen'], [SubscriptionController::class, 'index']);
 
 Route::group(['middleware' => 'auth'], static function () {
-    TranslatedRoute::get(['/integrations', '/integraties'], [IntegrationController::class, 'index'], 'integrations.index');
-    TranslatedRoute::get(['/integrations/create', '/integraties/nieuw'], [IntegrationController::class, 'create']);
+    TranslatedRoute::get(['en' => '/integrations', 'nl' => '/integraties'], [IntegrationController::class, 'index'], 'integrations.index');
+    TranslatedRoute::get(['en' => '/integrations/create', 'nl' => '/integraties/nieuw'], [IntegrationController::class, 'create']);
 
     Route::post('/integrations', [IntegrationController::class, 'store']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,7 @@ TranslatedRoute::get(['en' => '/subscriptions', 'nl' => '/abonnementen'], [Subsc
 
 Route::group(['middleware' => 'auth'], static function () {
     TranslatedRoute::get(['en' => '/integrations', 'nl' => '/integraties'], [IntegrationController::class, 'index'], 'integrations.index');
-    TranslatedRoute::get(['en' => '/integrations/create', 'nl' => '/integraties/nieuw'], [IntegrationController::class, 'create']);
+    TranslatedRoute::get(['en' => '/integrations/new', 'nl' => '/integraties/nieuw'], [IntegrationController::class, 'create']);
 
     Route::post('/integrations', [IntegrationController::class, 'store']);
 });


### PR DESCRIPTION
### Changed
- [Use a language to prefix the route name](https://github.com/cultuurnet/publiq-platform/commit/9891ae8dc6344b359d5b554e0f8f9c6469effb2a)
- [Use getTranslatedRouteName for integrations redirect](https://github.com/cultuurnet/publiq-platform/commit/543285044e04b63f75b9d27bf1a7cb7d7f5f2c58)
- [Pass Accept-Language header to post request integrations](https://github.com/cultuurnet/publiq-platform/commit/6515fc02fdb0d7d4d19a1664b99a77764c4506d4)

### Fixed
- Fix translated route name causing duplicate route names

---
Ticket: https://jira.uitdatabank.be/browse/PPF-167
