### PR TITLE
PPF-180 Disable deleting of login urls

### DIFF
--- a/app/Domain/Integrations/Policies/IntegrationUrlPolicy.php
+++ b/app/Domain/Integrations/Policies/IntegrationUrlPolicy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Integrations\Policies;
 
 use App\Domain\Auth\Models\UserModel;
+use App\Domain\Integrations\IntegrationUrlType;
 use App\Domain\Integrations\Models\IntegrationUrlModel;
 
 final class IntegrationUrlPolicy
@@ -31,7 +32,7 @@ final class IntegrationUrlPolicy
 
     public function delete(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool
     {
-        return true;
+        return ($integrationUrlModel->toDomain()->type !== IntegrationUrlType::Login);
     }
 
     public function restore(UserModel $userModel, IntegrationUrlModel $integrationUrlModel): bool


### PR DESCRIPTION
### Added
Can no longer delete login urls

I disabled deleting login urls because currently we cannot delete them because of a constraint in the SDK.
The class in the SDK cannot be extended because it is final.
A bug was logged with auth0.

I have another patch with a fix ready, but for now we will just disable the delete button.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-180