### PR TITLE
Add default IntegrationPartnerStatus to migration up

### DIFF
--- a/database/migrations/2023_09_28_101336_add_partner_status_to_integration.php
+++ b/database/migrations/2023_09_28_101336_add_partner_status_to_integration.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Domain\Integrations\IntegrationPartnerStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('integrations', static function (Blueprint $table) {
-            $table->string('partner_status')->after('status');
+            $table->string('partner_status')->default(IntegrationPartnerStatus::THIRD_PARTY->value)->after('status');
         });
     }
 


### PR DESCRIPTION
### Added

- Add default IntegrationPartnerStatus to migration up

### Fixed

- displaying of integrations failing because `""` is not a valid IntegrationPartnerStatus
