### PR TITLE
PPF-230: disable check on expires for tokens via ProjectAanvraag

### DIFF
--- a/app/Domain/Auth/Controllers/Token.php
+++ b/app/Domain/Auth/Controllers/Token.php
@@ -6,6 +6,7 @@ namespace App\Domain\Auth\Controllers;
 
 use App\Http\Controllers\Controller;
 use Auth0\SDK\Auth0;
+use Auth0\SDK\Token as Auth0Token;
 use Illuminate\Http\JsonResponse;
 
 final class Token extends Controller
@@ -15,7 +16,7 @@ final class Token extends Controller
         /** @var Auth0 $auth0 */
         $auth0 = app(Auth0::class);
         try {
-            $token = $auth0->decode($idToken);
+            $token = new Auth0Token($auth0->configuration(), $idToken, Auth0Token::TYPE_ID_TOKEN);
             return  new JsonResponse($token->toArray());
         } catch (\Exception $exception) {
             return new JsonResponse(


### PR DESCRIPTION
### Changed

- Disable check on `expires` for `JWT's` from `ProjectAanvraag`

### Fixed

- No more `expires` errors, when trying to manage a widget after being logged in for longer than 2 hours.

---
Ticket: https://jira.publiq.be/browse/PPF-230
