### PR TITLE
PPF-246 add findOrFail() with updateQuery

### DIFF
--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -45,8 +45,9 @@ final class EloquentIntegrationRepository implements IntegrationRepository
 
     public function update(Integration $integration): void
     {
-        IntegrationModel::query()->update([
-                'id' => $integration->id->toString(),
+        IntegrationModel::query()
+            ->findOrFail($integration->id->toString())
+            ->update([
                 'type' => $integration->type,
                 'name' => $integration->name,
                 'description' => $integration->description,

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -98,10 +98,10 @@ final class EloquentIntegrationRepositoryTest extends TestCase
         }
     }
 
-
     public function test_it_can_update_an_integration(): void
     {
         $integrationId = Uuid::uuid4();
+        $secondIntegrationId = Uuid::uuid4();
         $subscriptionId = Uuid::uuid4();
 
         $initialIntegration = new Integration(
@@ -115,6 +115,19 @@ final class EloquentIntegrationRepositoryTest extends TestCase
         );
 
         $this->integrationRepository->save($initialIntegration);
+
+        // @see https://jira.publiq.be/browse/PPF-246
+        $secondIntegration = new Integration(
+            $secondIntegrationId,
+            IntegrationType::SearchApi,
+            'Second Integration',
+            'Second Integration description',
+            $subscriptionId,
+            IntegrationStatus::Draft,
+            IntegrationPartnerStatus::THIRD_PARTY,
+        );
+
+        $this->integrationRepository->save($secondIntegration);
 
         $updatedIntegration = new Integration(
             $initialIntegration->id,


### PR DESCRIPTION
### Added

- `EloquentIntegrationRepository`: added a `findOrFail()` when an `Integration` has an `update`.

### Changed

- `EloquentIntegrationRepositoryTest`: make `test_it_can_update_an_integration()` more robust by adding a second integration.

### Fixed

- It is now possible to change the `name` (and other fields like `description`), without causing an `Integrity constraint violation`.

---
Ticket: https://jira.publiq.be/browse/PPF-246