### PR TITLE
PPF-239 delete contributors

### DIFF
--- a/app/Domain/Contacts/Repositories/EloquentContactRepository.php
+++ b/app/Domain/Contacts/Repositories/EloquentContactRepository.php
@@ -29,7 +29,7 @@ final class EloquentContactRepository implements ContactRepository
     }
     public function delete(UuidInterface $id): void
     {
-        ContactModel::query()->where('id', $id->toString())->delete();
+        ContactModel::query()->where('id', $id->toString())->forceDelete();
     }
 
     public function getById(UuidInterface $id): Contact


### PR DESCRIPTION
### Changed

- `EloquentContactRepository`: Deleting a `Contributor` will result in a hard delete.
(Functional/Technical contacts cannot be deleted, because of https://github.com/cultuurnet/publiq-platform/blob/c583f03ef63cfdeca3c7e350dfc6cb3991ea9fc2/app/Domain/Contacts/Policies/ContactPolicy.php#L33 )

### Fixed

- An accidentally deleted `Contributor`, can be added again, without causing a `CONSTRAINT VIOLATION`

---
Ticket: https://jira.publiq.be/browse/PPF-239