### PR TITLE
Add `dev-publiq` as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS are automatically assigned as possible reviewers to new PRs.
 
 # Global owners (also need to be duplicated in later rules)
-* @LucWollants @JonasVHG @brampauwelyn @simon-debruijn @vhande @grubolsch
+* @LucWollants @JonasVHG @brampauwelyn @simon-debruijn @vhande @grubolsch @dev-publiq
 
 # Jenkins / deployment owners
 Gemfile* @willaerk @paulherbosch


### PR DESCRIPTION
### Added
- Added `dev-publiq` as code owner so the dependabot pull requests which are auto approved by `dev-publiq` also get merged