### PR TITLE
PPF-258 Expose distributed_at in Nova

### DIFF
--- a/app/Auth0/Models/Auth0ClientModel.php
+++ b/app/Auth0/Models/Auth0ClientModel.php
@@ -11,6 +11,7 @@ use App\Models\UuidModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Ramsey\Uuid\Uuid;
+use Spatie\Activitylog\LogOptions;
 
 final class Auth0ClientModel extends UuidModel
 {
@@ -30,6 +31,11 @@ final class Auth0ClientModel extends UuidModel
     protected $casts = [
         'distributed_at' => 'datetime',
     ];
+
+    public function isDistributed(): bool
+    {
+        return $this->distributed_at !== null;
+    }
 
     public function toDomain(): Auth0Client
     {

--- a/app/Auth0/Models/Auth0ClientModel.php
+++ b/app/Auth0/Models/Auth0ClientModel.php
@@ -11,7 +11,6 @@ use App\Models\UuidModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Ramsey\Uuid\Uuid;
-use Spatie\Activitylog\LogOptions;
 
 final class Auth0ClientModel extends UuidModel
 {

--- a/app/Auth0/Models/Auth0ClientModel.php
+++ b/app/Auth0/Models/Auth0ClientModel.php
@@ -27,6 +27,10 @@ final class Auth0ClientModel extends UuidModel
         'distributed_at',
     ];
 
+    protected $casts = [
+        'distributed_at' => 'datetime',
+    ];
+
     public function toDomain(): Auth0Client
     {
         return new Auth0Client(

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -51,6 +51,21 @@ final class IntegrationModel extends UuidModel
         'partner_status' => IntegrationPartnerStatus::THIRD_PARTY,
     ];
 
+    public function canBeActivated(): bool
+    {
+        return $this->status !== IntegrationStatus::Active->value;
+    }
+
+    public function canBeBlocked(): bool
+    {
+        return $this->status !== IntegrationStatus::Blocked->value;
+    }
+
+    public function isWidgets(): bool
+    {
+        return $this->type === IntegrationType::Widgets->value;
+    }
+
     protected static function booted(): void
     {
         self::created(

--- a/app/Nova/Actions/Auth0/DistributeAuth0Client.php
+++ b/app/Nova/Actions/Auth0/DistributeAuth0Client.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions\Auth0;
+
+use App\Auth0\Models\Auth0ClientModel;
+use App\Auth0\Repositories\Auth0ClientRepository;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\ActionResponse;
+use Laravel\Nova\Fields\ActionFields;
+
+final class DistributeAuth0Client extends Action
+{
+    public function __construct(private readonly Auth0ClientRepository $repository)
+    {
+    }
+
+    public function handle(ActionFields $fields, Collection $auth0Clients): Action|ActionResponse
+    {
+        $this->repository->distribute(
+            ...$auth0Clients->map(fn (Auth0ClientModel $auth0Client) => $auth0Client->toDomain())
+        );
+
+        return Action::message('Distributed Auth0 clients');
+    }
+}

--- a/app/Nova/Actions/UiTiDv1/DistributeUiTiDv1Consumer.php
+++ b/app/Nova/Actions/UiTiDv1/DistributeUiTiDv1Consumer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions\UiTiDv1;
+
+use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\ActionResponse;
+use Laravel\Nova\Fields\ActionFields;
+
+final class DistributeUiTiDv1Consumer extends Action
+{
+    public function __construct(private readonly UiTiDv1ConsumerRepository $repository)
+    {
+    }
+
+    public function handle(ActionFields $fields, Collection $uiTiDv1Consumers): Action|ActionResponse
+    {
+        $this->repository->distribute(
+            ...$uiTiDv1Consumers->map(fn (UiTiDv1ConsumerModel $uiTiDv1Consumer) => $uiTiDv1Consumer->toDomain())
+        );
+
+        return Action::message('Distributed UiTiDv1 consumers');
+    }
+}

--- a/app/Nova/Resources/Auth0Client.php
+++ b/app/Nova/Resources/Auth0Client.php
@@ -7,11 +7,13 @@ namespace App\Nova\Resources;
 use App\Auth0\Auth0Tenant;
 use App\Auth0\CachedAuth0ClientGrants;
 use App\Auth0\Models\Auth0ClientModel;
+use App\Nova\ActionGuards\ActionGuard;
 use App\Nova\ActionGuards\Auth0\ActivateAuth0ClientGuard;
 use App\Nova\ActionGuards\Auth0\BlockAuth0ClientGuard;
 use App\Nova\Actions\Auth0\ActivateAuth0Client;
 use App\Nova\Actions\Auth0\BlockAuth0Client;
 use App\Nova\Resource;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use Laravel\Nova\Fields\DateTime;
@@ -19,10 +21,12 @@ use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Http\Requests\ActionRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 /**
  * @mixin Auth0ClientModel
+ * @property Auth0ClientModel $resource
  */
 final class Auth0Client extends Resource
 {
@@ -110,27 +114,42 @@ final class Auth0Client extends Resource
     {
         return [
             App::make(ActivateAuth0Client::class)
-                ->showOnDetail()
-                ->showInline()
+                ->exceptOnIndex()
                 ->confirmText('Are you sure you want to activate this client?')
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate")
-                ->canRun(function ($request, $model) {
-                    /** @var ActivateAuth0ClientGuard $guard */
-                    $guard = App::make(ActivateAuth0ClientGuard::class);
-                    return $guard->canDo($model->toDomain());
-                }),
+                ->canSee(fn(Request $request) => $this->canActivate($request, $this->resource))
+                ->canRun(fn($request, $model) => $this->canActivate($request, $model)),
             App::make(BlockAuth0Client::class)
-                ->showOnDetail()
-                ->showInline()
+                ->exceptOnIndex()
                 ->confirmText('Are you sure you want to block this client?')
                 ->confirmButtonText('Block')
                 ->cancelButtonText("Don't block")
-                ->canRun(function ($request, $model) {
-                    /** @var BlockAuth0ClientGuard $guard */
-                    $guard = App::make(BlockAuth0ClientGuard::class);
-                    return $guard->canDo($model->toDomain());
-                }),
+                ->canSee(fn(Request $request) => $this->canBlock($request, $this->resource))
+                ->canRun(fn($request, $model) => $this->canBlock($request, $model)),
         ];
+    }
+
+    private function canActivate(Request $request, ?Auth0ClientModel $model): bool
+    {
+        return $this->can($request, $model, App::make(ActivateAuth0ClientGuard::class));
+    }
+
+    private function canBlock(Request $request, ?Auth0ClientModel $model): bool
+    {
+        return $this->can($request, $model, App::make(BlockAuth0ClientGuard::class));
+    }
+
+    private function can(Request $request, ?Auth0ClientModel $model, ActionGuard $guard): bool
+    {
+        if ($request instanceof ActionRequest) {
+            return true;
+        }
+
+        if ($model === null) {
+            return false;
+        }
+
+        return $guard->canDo($model->toDomain());
     }
 }

--- a/app/Nova/Resources/Auth0Client.php
+++ b/app/Nova/Resources/Auth0Client.php
@@ -118,15 +118,15 @@ final class Auth0Client extends Resource
                 ->confirmText('Are you sure you want to activate this client?')
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate")
-                ->canSee(fn(Request $request) => $this->canActivate($request, $this->resource))
-                ->canRun(fn($request, $model) => $this->canActivate($request, $model)),
+                ->canSee(fn (Request $request) => $this->canActivate($request, $this->resource))
+                ->canRun(fn ($request, $model) => $this->canActivate($request, $model)),
             App::make(BlockAuth0Client::class)
                 ->exceptOnIndex()
                 ->confirmText('Are you sure you want to block this client?')
                 ->confirmButtonText('Block')
                 ->cancelButtonText("Don't block")
-                ->canSee(fn(Request $request) => $this->canBlock($request, $this->resource))
-                ->canRun(fn($request, $model) => $this->canBlock($request, $model)),
+                ->canSee(fn (Request $request) => $this->canBlock($request, $this->resource))
+                ->canRun(fn ($request, $model) => $this->canBlock($request, $model)),
         ];
     }
 

--- a/app/Nova/Resources/Auth0Client.php
+++ b/app/Nova/Resources/Auth0Client.php
@@ -7,7 +7,6 @@ namespace App\Nova\Resources;
 use App\Auth0\Auth0Tenant;
 use App\Auth0\CachedAuth0ClientGrants;
 use App\Auth0\Models\Auth0ClientModel;
-use App\Domain\Contacts\Models\ContactModel;
 use App\Nova\ActionGuards\Auth0\ActivateAuth0ClientGuard;
 use App\Nova\ActionGuards\Auth0\BlockAuth0ClientGuard;
 use App\Nova\Actions\Auth0\ActivateAuth0Client;
@@ -15,6 +14,7 @@ use App\Nova\Actions\Auth0\BlockAuth0Client;
 use App\Nova\Resource;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
+use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
@@ -22,7 +22,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 /**
- * @mixin ContactModel
+ * @mixin Auth0ClientModel
  */
 final class Auth0Client extends Resource
 {
@@ -71,6 +71,8 @@ final class Auth0Client extends Resource
                 Log::debug('Auth0Client - status - ' . $auth0Client->clientId . ': active');
                 return '<span style="color: green;">Active</span>';
             })->asHtml(),
+            DateTime::make('distributed_at')
+                ->readonly(),
             Text::make('auth0_client_id')
                 ->readonly(),
             Text::make('auth0_client_secret')

--- a/app/Nova/Resources/Auth0Client.php
+++ b/app/Nova/Resources/Auth0Client.php
@@ -12,6 +12,7 @@ use App\Nova\ActionGuards\Auth0\ActivateAuth0ClientGuard;
 use App\Nova\ActionGuards\Auth0\BlockAuth0ClientGuard;
 use App\Nova\Actions\Auth0\ActivateAuth0Client;
 use App\Nova\Actions\Auth0\BlockAuth0Client;
+use App\Nova\Actions\Auth0\DistributeAuth0Client;
 use App\Nova\Resource;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -120,6 +121,7 @@ final class Auth0Client extends Resource
                 ->cancelButtonText("Don't activate")
                 ->canSee(fn (Request $request) => $this->canActivate($request, $this->resource))
                 ->canRun(fn ($request, $model) => $this->canActivate($request, $model)),
+
             App::make(BlockAuth0Client::class)
                 ->exceptOnIndex()
                 ->confirmText('Are you sure you want to block this client?')
@@ -127,6 +129,14 @@ final class Auth0Client extends Resource
                 ->cancelButtonText("Don't block")
                 ->canSee(fn (Request $request) => $this->canBlock($request, $this->resource))
                 ->canRun(fn ($request, $model) => $this->canBlock($request, $model)),
+
+            App::make(DistributeAuth0Client::class)
+                ->exceptOnIndex()
+                ->confirmText('Are you sure you want to distribute this client?')
+                ->confirmButtonText('Distribute')
+                ->cancelButtonText("Don't distribute")
+                ->canSee(fn (Request $request) => !$this->resource->isDistributed())
+                ->canRun(fn ($request, $model) => !$this->resource->isDistributed()),
         ];
     }
 

--- a/app/Nova/Resources/Auth0Client.php
+++ b/app/Nova/Resources/Auth0Client.php
@@ -120,7 +120,7 @@ final class Auth0Client extends Resource
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate")
                 ->canSee(fn (Request $request) => $this->canActivate($request, $this->resource))
-                ->canRun(fn ($request, $model) => $this->canActivate($request, $model)),
+                ->canRun(fn (Request $request, Auth0ClientModel $model) => $this->canActivate($request, $model)),
 
             App::make(BlockAuth0Client::class)
                 ->exceptOnIndex()
@@ -128,7 +128,7 @@ final class Auth0Client extends Resource
                 ->confirmButtonText('Block')
                 ->cancelButtonText("Don't block")
                 ->canSee(fn (Request $request) => $this->canBlock($request, $this->resource))
-                ->canRun(fn ($request, $model) => $this->canBlock($request, $model)),
+                ->canRun(fn (Request $request, Auth0ClientModel $model) => $this->canBlock($request, $model)),
 
             App::make(DistributeAuth0Client::class)
                 ->exceptOnIndex()
@@ -136,7 +136,7 @@ final class Auth0Client extends Resource
                 ->confirmButtonText('Distribute')
                 ->cancelButtonText("Don't distribute")
                 ->canSee(fn (Request $request) => !$this->resource->isDistributed())
-                ->canRun(fn ($request, $model) => !$this->resource->isDistributed()),
+                ->canRun(fn (Request $request, Auth0ClientModel $model) => !$this->resource->isDistributed()),
         ];
     }
 

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -24,7 +24,6 @@ use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Http\Requests\ActionRequest;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\ResourceTool;
 use Publiq\InsightlyLink\InsightlyLink;

--- a/app/Nova/Resources/UiTiDv1.php
+++ b/app/Nova/Resources/UiTiDv1.php
@@ -7,7 +7,6 @@ namespace App\Nova\Resources;
 use App\Nova\ActionGuards\ActionGuard;
 use App\Nova\ActionGuards\UiTiDv1\ActivateUiTiDv1ConsumerGuard;
 use App\Nova\ActionGuards\UiTiDv1\BlockUiTiDv1ConsumerGuard;
-use App\Nova\Actions\Auth0\DistributeAuth0Client;
 use App\Nova\Actions\UiTiDv1\ActivateUiTiDv1Consumer;
 use App\Nova\Actions\UiTiDv1\BlockUiTiDv1Consumer;
 use App\Nova\Actions\UiTiDv1\DistributeUiTiDv1Consumer;

--- a/app/Nova/Resources/UiTiDv1.php
+++ b/app/Nova/Resources/UiTiDv1.php
@@ -7,8 +7,10 @@ namespace App\Nova\Resources;
 use App\Nova\ActionGuards\ActionGuard;
 use App\Nova\ActionGuards\UiTiDv1\ActivateUiTiDv1ConsumerGuard;
 use App\Nova\ActionGuards\UiTiDv1\BlockUiTiDv1ConsumerGuard;
+use App\Nova\Actions\Auth0\DistributeAuth0Client;
 use App\Nova\Actions\UiTiDv1\ActivateUiTiDv1Consumer;
 use App\Nova\Actions\UiTiDv1\BlockUiTiDv1Consumer;
+use App\Nova\Actions\UiTiDv1\DistributeUiTiDv1Consumer;
 use App\Nova\Resource;
 use App\UiTiDv1\CachedUiTiDv1Status;
 use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
@@ -132,6 +134,13 @@ final class UiTiDv1 extends Resource
                 ->canSee(fn (Request $request) => $this->canBlock($request, $this->resource))
                 ->canRun(fn ($request, $model) => $this->canBlock($request, $model)),
 
+            App::make(DistributeUiTiDv1Consumer::class)
+                ->exceptOnIndex()
+                ->confirmText('Are you sure you want to distribute this consumer?')
+                ->confirmButtonText('Distribute')
+                ->cancelButtonText("Don't distribute")
+                ->canSee(fn (Request $request) => !$this->resource->isDistributed())
+                ->canRun(fn ($request, $model) => !$this->resource->isDistributed()),
         ];
     }
 

--- a/app/Nova/Resources/UiTiDv1.php
+++ b/app/Nova/Resources/UiTiDv1.php
@@ -121,7 +121,7 @@ final class UiTiDv1 extends Resource
                 ->confirmText('Are you sure you want to activate this consumer?')
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate")
-                ->canSee(fn(Request $request) => $this->canActivate($request, $this->resource))
+                ->canSee(fn (Request $request) => $this->canActivate($request, $this->resource))
                 ->canRun(fn ($request, $model) => $this->canActivate($request, $model)),
 
             App::make(BlockUiTiDv1Consumer::class)
@@ -129,7 +129,7 @@ final class UiTiDv1 extends Resource
                 ->confirmText('Are you sure you want to block this consumer?')
                 ->confirmButtonText('Block')
                 ->cancelButtonText("Don't block")
-                ->canSee(fn(Request $request) => $this->canBlock($request, $this->resource))
+                ->canSee(fn (Request $request) => $this->canBlock($request, $this->resource))
                 ->canRun(fn ($request, $model) => $this->canBlock($request, $model)),
 
         ];

--- a/app/Nova/Resources/UiTiDv1.php
+++ b/app/Nova/Resources/UiTiDv1.php
@@ -15,6 +15,7 @@ use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
 use App\UiTiDv1\UiTiDv1ConsumerStatus;
 use App\UiTiDv1\UiTiDv1Environment;
 use Illuminate\Support\Facades\App;
+use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
@@ -72,6 +73,8 @@ final class UiTiDv1 extends Resource
                     $status->name
                 );
             })->asHtml(),
+            DateTime::make('distributed_at')
+                ->readonly(),
             Text::make('consumer_key')
                 ->readonly(),
             Text::make('consumer_secret')

--- a/app/Nova/Resources/UiTiDv1.php
+++ b/app/Nova/Resources/UiTiDv1.php
@@ -123,7 +123,7 @@ final class UiTiDv1 extends Resource
                 ->confirmButtonText('Activate')
                 ->cancelButtonText("Don't activate")
                 ->canSee(fn (Request $request) => $this->canActivate($request, $this->resource))
-                ->canRun(fn ($request, $model) => $this->canActivate($request, $model)),
+                ->canRun(fn (Request $request, UiTiDv1ConsumerModel $model) => $this->canActivate($request, $model)),
 
             App::make(BlockUiTiDv1Consumer::class)
                 ->exceptOnIndex()
@@ -131,7 +131,7 @@ final class UiTiDv1 extends Resource
                 ->confirmButtonText('Block')
                 ->cancelButtonText("Don't block")
                 ->canSee(fn (Request $request) => $this->canBlock($request, $this->resource))
-                ->canRun(fn ($request, $model) => $this->canBlock($request, $model)),
+                ->canRun(fn (Request $request, UiTiDv1ConsumerModel $model) => $this->canBlock($request, $model)),
 
             App::make(DistributeUiTiDv1Consumer::class)
                 ->exceptOnIndex()
@@ -139,7 +139,7 @@ final class UiTiDv1 extends Resource
                 ->confirmButtonText('Distribute')
                 ->cancelButtonText("Don't distribute")
                 ->canSee(fn (Request $request) => !$this->resource->isDistributed())
-                ->canRun(fn ($request, $model) => !$this->resource->isDistributed()),
+                ->canRun(fn (Request $request, UiTiDv1ConsumerModel $model) => !$this->resource->isDistributed()),
         ];
     }
 

--- a/app/UiTiDv1/Models/UiTiDv1ConsumerModel.php
+++ b/app/UiTiDv1/Models/UiTiDv1ConsumerModel.php
@@ -33,6 +33,11 @@ final class UiTiDv1ConsumerModel extends UuidModel
         'distributed_at' => 'datetime',
     ];
 
+    public function isDistributed(): bool
+    {
+        return $this->distributed_at !== null;
+    }
+
     public function toDomain(): UiTiDv1Consumer
     {
         return new UiTiDv1Consumer(

--- a/app/UiTiDv1/Models/UiTiDv1ConsumerModel.php
+++ b/app/UiTiDv1/Models/UiTiDv1ConsumerModel.php
@@ -29,6 +29,10 @@ final class UiTiDv1ConsumerModel extends UuidModel
         'distributed_at',
     ];
 
+    protected $casts = [
+        'distributed_at' => 'datetime',
+    ];
+
     public function toDomain(): UiTiDv1Consumer
     {
         return new UiTiDv1Consumer(


### PR DESCRIPTION
### Added
- Added `distributed_at` column in Nova on Auth0 Client and UiTiD Consumer
- Added action to distribute Auth0 Client or UiTiD Consumer

### Changed
- Show activate/block actions based on the state of the Auth0 Client or UiTiD Consumer
- Show actions on Integration correctly based on state and type

### Note
- This also fixes https://jira.publiq.be/browse/PPF-294

---
Ticket: https://jira.uitdatabank.be/browse/PPF-258
