### PR TITLE
PPF-300 - Fix e2e-install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ npm-types-check:
 	vendor/bin/sail npm run types:check
 
 e2e-install:
-	vendor/bin/sail npx playwright install chromium
+	docker-compose exec laravel npx playwright install chromium --with-deps
 
 test-e2e:
 	vendor/bin/sail npx playwright test $(options)


### PR DESCRIPTION
### Fixed
- [Fix e2e-install command](https://github.com/cultuurnet/publiq-platform/commit/c25039a6c85064b59b3b9c714167f5e8e82cad16)

---
Ticket: https://jira.uitdatabank.be/browse/PPF-300

Docker compose exec seems to execute as root user, whereas sail doesn't and prompts for the root password
