### PR TITLE
PPF-314 activation endpoint

### DIFF
--- a/app/Domain/Integrations/Controllers/IntegrationController.php
+++ b/app/Domain/Integrations/Controllers/IntegrationController.php
@@ -271,6 +271,7 @@ final class IntegrationController extends Controller
         return Redirect::back();
     }
 
+    // @deprecated
     public function activateWithCoupon(string $id, ActivateWithCouponRequest $request): RedirectResponse
     {
         try {
@@ -290,6 +291,7 @@ final class IntegrationController extends Controller
         }
     }
 
+    // @deprecated
     public function activateWithOrganization(string $id, CreateOrganizationRequest $request): RedirectResponse
     {
         $organization = OrganizationMapper::mapCreate($request);

--- a/app/Domain/Integrations/Events/IntegrationActivationRequested.php
+++ b/app/Domain/Integrations/Events/IntegrationActivationRequested.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Ramsey\Uuid\UuidInterface;
+
+final class IntegrationActivationRequested
+{
+    use Dispatchable;
+
+    public function __construct(public readonly UuidInterface $id)
+    {
+    }
+}

--- a/app/Domain/Integrations/FormRequests/ActivateWithCouponRequest.php
+++ b/app/Domain/Integrations/FormRequests/ActivateWithCouponRequest.php
@@ -6,6 +6,7 @@ namespace App\Domain\Integrations\FormRequests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+// @deprecated
 final class ActivateWithCouponRequest extends FormRequest
 {
     public function rules(): array

--- a/app/Domain/Integrations/FormRequests/CreateOrganizationRequest.php
+++ b/app/Domain/Integrations/FormRequests/CreateOrganizationRequest.php
@@ -15,12 +15,12 @@ final class CreateOrganizationRequest extends FormRequest
     {
         return [
             'organization.name' => ['required', 'string', 'max:255'],
-            'organization.invoiceEmail' => ['required', 'string', 'email', 'min:2', 'max:255'],
-            'organization.vat' => ['nullable', 'string', 'max:255'],
             'organization.address.street' => ['required', 'string', 'max:255'],
             'organization.address.zip' => ['required', 'string', 'max:255'],
             'organization.address.city' => ['required', 'string', 'max:255'],
             'organization.address.country' => ['required', 'string', 'max:255'],
+            'organization.invoiceEmail' => ['required_with:organization.vat', 'string', 'email', 'min:2', 'max:255'],
+            'organization.vat' => ['required_with:organization.invoiceEmail', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Domain/Integrations/FormRequests/RequestActivationRequest.php
+++ b/app/Domain/Integrations/FormRequests/RequestActivationRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\FormRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class RequestActivationRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return array_merge(
+            (new CreateOrganizationRequest())->rules(),
+            [
+                'coupon' => ['nullable', 'string', 'max:255'],
+            ]
+        );
+    }
+}

--- a/app/Domain/Integrations/Mappers/OrganizationMapper.php
+++ b/app/Domain/Integrations/Mappers/OrganizationMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Integrations\Mappers;
 
 use App\Domain\Integrations\FormRequests\CreateOrganizationRequest;
+use App\Domain\Integrations\FormRequests\RequestActivationRequest;
 use App\Domain\Integrations\FormRequests\UpdateOrganizationRequest;
 use App\Domain\Organizations\Address;
 use App\Domain\Organizations\Organization;
@@ -19,6 +20,11 @@ final class OrganizationMapper
     }
 
     public static function mapUpdate(UpdateOrganizationRequest $request): Organization
+    {
+        return self::map($request);
+    }
+
+    public static function mapActivationRequest(RequestActivationRequest $request): Organization
     {
         return self::map($request);
     }

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -102,6 +102,7 @@ final class IntegrationModel extends UuidModel
         IntegrationActivated::dispatch(Uuid::fromString($this->id));
     }
 
+    // @deprecated
     public function activateWithCoupon(): void
     {
         $this->update([
@@ -110,6 +111,7 @@ final class IntegrationModel extends UuidModel
         IntegrationActivatedWithCoupon::dispatch(Uuid::fromString($this->id));
     }
 
+    // @deprecated
     public function activateWithOrganization(UuidInterface $organizationId): void
     {
         $this->update([

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -10,6 +10,7 @@ use App\Domain\Coupons\Models\CouponModel;
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivatedWithCoupon;
 use App\Domain\Integrations\Events\IntegrationActivatedWithOrganization;
+use App\Domain\Integrations\Events\IntegrationActivationRequested;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Events\IntegrationUpdated;
@@ -81,6 +82,15 @@ final class IntegrationModel extends UuidModel
     {
         $this->update(['status' => IntegrationStatus::Deleted]);
         return parent::delete();
+    }
+
+    public function requestActivation(UuidInterface $organizationId): void
+    {
+        $this->update([
+            'organization_id' => $organizationId->toString(),
+            'status' => IntegrationStatus::PendingApprovalIntegration,
+        ]);
+        IntegrationActivationRequested::dispatch(Uuid::fromString($this->id));
     }
 
     public function activate(UuidInterface $organizationId): void

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -98,6 +98,24 @@ final class EloquentIntegrationRepository implements IntegrationRepository
         );
     }
 
+    public function requestActivation(UuidInterface $id, UuidInterface $organizationId, ?string $couponCode): void
+    {
+        DB::transaction(static function () use ($couponCode, $id, $organizationId): void {
+            if ($couponCode) {
+                /** @var CouponModel $couponModel */
+                $couponModel = CouponModel::query()
+                    ->where('code', '=', $couponCode)
+                    ->whereNull('integration_id')
+                    ->firstOrFail();
+                $couponModel->useOnIntegration($id);
+            }
+
+            /** @var IntegrationModel $integrationModel */
+            $integrationModel = IntegrationModel::query()->findOrFail($id->toString());
+            $integrationModel->requestActivation($organizationId);
+        });
+    }
+
     public function activate(UuidInterface $id, UuidInterface $organizationId, ?string $couponCode): void
     {
         DB::transaction(static function () use ($couponCode, $id, $organizationId): void {

--- a/app/Domain/Integrations/Repositories/IntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/IntegrationRepository.php
@@ -15,6 +15,7 @@ interface IntegrationRepository
     public function getById(UuidInterface $id): Integration;
     public function deleteById(UuidInterface $id): ?bool;
     public function getByContactEmail(string $email, ?string $searchQuery): PaginatedCollection;
+    public function requestActivation(UuidInterface $id, UuidInterface $organizationId, ?string $couponCode): void;
     public function activate(UuidInterface $id, UuidInterface $organizationId, ?string $couponCode): void;
     // @deprecated
     public function activateWithCouponCode(UuidInterface $id, string $couponCode): void;

--- a/app/Insightly/InsightlyServiceProvider.php
+++ b/app/Insightly/InsightlyServiceProvider.php
@@ -9,6 +9,7 @@ use App\Domain\Contacts\Events\ContactUpdated;
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivatedWithCoupon;
 use App\Domain\Integrations\Events\IntegrationActivatedWithOrganization;
+use App\Domain\Integrations\Events\IntegrationActivationRequested;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Events\IntegrationUpdated;
@@ -55,9 +56,12 @@ final class InsightlyServiceProvider extends ServiceProvider
         if (config('insightly.enabled')) {
             Event::listen(IntegrationCreated::class, [CreateOpportunity::class, 'handle']);
 
+            // @deprecated
             Event::listen(IntegrationActivatedWithCoupon::class, [CreateProjectWithCoupon::class, 'handle']);
+            // @deprecated
             Event::listen(IntegrationActivatedWithOrganization::class, [CreateProjectWithOrganization::class, 'handle']);
 
+            Event::listen(IntegrationActivationRequested::class, [ActivateProject::class, 'handle']);
             Event::listen(IntegrationActivated::class, [ActivateProject::class, 'handle']);
 
             Event::listen(IntegrationBlocked::class, [BlockProject::class, 'handle']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -97,6 +97,8 @@ Route::group(['middleware' => 'auth'], static function () {
 
         Route::patch('/integrations/{id}/organization', [IntegrationController::class, 'updateOrganization']);
 
+        Route::post('/integrations/{id}/activation', [IntegrationController::class, 'requestActivation']);
+
         Route::post('/integrations/{id}/coupon', [IntegrationController::class, 'activateWithCoupon']);
         Route::post('/integrations/{id}/organization', [IntegrationController::class, 'activateWithOrganization']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,8 +104,6 @@ Route::group(['middleware' => 'auth'], static function () {
         // @deprecated
         Route::post('/integrations/{id}/organization', [IntegrationController::class, 'activateWithOrganization']);
 
-        Route::post('/integrations/{id}/auth0-clients', [IntegrationController::class, 'distributeAuth0Clients']);
-
         Route::get('/integrations/{id}/widget', [IntegrationController::class, 'showWidget']);
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,7 +99,9 @@ Route::group(['middleware' => 'auth'], static function () {
 
         Route::post('/integrations/{id}/activation', [IntegrationController::class, 'requestActivation']);
 
+        // @deprecated
         Route::post('/integrations/{id}/coupon', [IntegrationController::class, 'activateWithCoupon']);
+        // @deprecated
         Route::post('/integrations/{id}/organization', [IntegrationController::class, 'activateWithOrganization']);
 
         Route::post('/integrations/{id}/auth0-clients', [IntegrationController::class, 'distributeAuth0Clients']);

--- a/tests/Domain/Integrations/Controllers/IntegrationControllerTest.php
+++ b/tests/Domain/Integrations/Controllers/IntegrationControllerTest.php
@@ -113,6 +113,119 @@ final class IntegrationControllerTest extends TestCase
         ]);
     }
 
+    public function test_it_can_not_request_activation_if_not_authorized(): void
+    {
+        $this->actingAs(UserModel::createSystemUser());
+
+        $integration = $this->givenThereIsAnIntegration();
+        $organization = $this->givenThereIsAnOrganization();
+
+        $response = $this->post(
+            "/integrations/{$integration->id}/activation",
+            [
+                'organization' => [
+                    'id' => $organization->id->toString(),
+                    'name' => $organization->name,
+                    'vat' => $organization->vat,
+                    'invoiceEmail' => $organization->invoiceEmail,
+                    'address' => [
+                        'street' => $organization->address->street,
+                        'zip' => $organization->address->zip,
+                        'city' => $organization->address->city,
+                        'country' => $organization->address->country,
+                    ],
+                ],
+            ]
+        );
+
+        $response->assertForbidden();
+
+        $this->assertDatabaseMissing('integrations', [
+            'id' => $integration->id->toString(),
+            'status' => IntegrationStatus::PendingApprovalIntegration,
+        ]);
+    }
+
+    public function test_it_can_request_activation_with_an_organization(): void
+    {
+        $this->actingAs(UserModel::createSystemUser());
+
+        $organization = $this->givenThereIsAnOrganization();
+        $integration = $this->givenThereIsAnIntegration();
+
+        $this->givenTheActingUserIsAContactOnIntegration($integration);
+
+        $response = $this->post(
+            "/integrations/{$integration->id}/activation",
+            [
+                'organization' => [
+                    'id' => $organization->id->toString(),
+                    'name' => $organization->name,
+                    'vat' => $organization->vat,
+                    'invoiceEmail' => $organization->invoiceEmail,
+                    'address' => [
+                        'street' => $organization->address->street,
+                        'zip' => $organization->address->zip,
+                        'city' => $organization->address->city,
+                        'country' => $organization->address->country,
+                    ],
+                ],
+            ]
+        );
+
+        $response->assertRedirect('/');
+
+        $this->assertDatabaseHas('integrations', [
+            'id' => $integration->id->toString(),
+            'organization_id' => $organization->id,
+            'status' => IntegrationStatus::PendingApprovalIntegration,
+        ]);
+    }
+
+    public function test_it_can_request_activation_with_an_organization_and_coupon(): void
+    {
+        $this->actingAs(UserModel::createSystemUser());
+
+        $organization = $this->givenThereIsAnOrganization();
+        $integration = $this->givenThereIsAnIntegration();
+        $coupon = $this->givenThereIsACoupon();
+
+        $this->givenTheActingUserIsAContactOnIntegration($integration);
+
+        $response = $this->post(
+            "/integrations/{$integration->id}/activation",
+            [
+                'organization' => [
+                    'id' => $organization->id->toString(),
+                    'name' => $organization->name,
+                    'vat' => $organization->vat,
+                    'invoiceEmail' => $organization->invoiceEmail,
+                    'address' => [
+                        'street' => $organization->address->street,
+                        'zip' => $organization->address->zip,
+                        'city' => $organization->address->city,
+                        'country' => $organization->address->country,
+                    ],
+                ],
+                'coupon' => $coupon->code,
+            ]
+        );
+
+        $response->assertRedirect('/');
+
+        $this->assertDatabaseHas('integrations', [
+            'id' => $integration->id->toString(),
+            'organization_id' => $organization->id,
+            'status' => IntegrationStatus::PendingApprovalIntegration,
+        ]);
+
+        $this->assertDatabaseHas('coupons', [
+            'id' => $coupon->id,
+            'integration_id' => $integration->id->toString(),
+        ]);
+    }
+
+    // @deprecated
     public function test_it_can_activate_an_integration_with_a_coupon(): void
     {
         $this->actingAs(UserModel::createSystemUser());
@@ -141,6 +254,7 @@ final class IntegrationControllerTest extends TestCase
         ]);
     }
 
+    // @deprecated
     public function test_it_can_not_activate_an_integration_with_a_coupon_if_not_authorized(): void
     {
         $this->actingAs(UserModel::createSystemUser());
@@ -168,6 +282,7 @@ final class IntegrationControllerTest extends TestCase
         ]);
     }
 
+    // @deprecated
     public function test_it_can_activate_an_integration_with_an_organization(): void
     {
         $this->actingAs(UserModel::createSystemUser());
@@ -203,6 +318,7 @@ final class IntegrationControllerTest extends TestCase
         ]);
     }
 
+    // @deprecated
     public function test_it_can_not_activate_an_integration_with_an_organization_if_not_authorized(): void
     {
         $this->actingAs(UserModel::createSystemUser());
@@ -901,8 +1017,8 @@ final class IntegrationControllerTest extends TestCase
 
     private function givenTheIntegrationIsActivatedWithOrganisation(Integration $integration, Organization $organization): void
     {
-        $response = $this->post(
-            "/integrations/{$integration->id}/organization",
+        $this->post(
+            "/integrations/{$integration->id}/activation",
             [
                 'organization' => [
                     'id' => $organization->id->toString(),


### PR DESCRIPTION
### Added
- Added a new endpoint to request the activation of an integration. This always requires basic organization details and optional coupon and/or optional VAT details.

### Note
- The flow is exactly the same as a full activation, only the internal state of the integration is pending approval.

### Next steps
- Once the frontend changes are done it should be possible to remove all the deprecated code
- In the Laravel Nova admin panel an approval action needs to be added
- The link between activation and distribution of keys needs to be removed
- A combination of integration state and new field v1_allowed can replace the distributed_at field

---
Ticket: https://jira.uitdatabank.be/browse/PPF-314
