### PR TITLE
PPF-344 - As an admin I can create an integration

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -133,3 +133,10 @@ INSIGHTLY_API_KEY=
 
 SENTRY_LARAVEL_ENABLED=true
 SENTRY_LARAVEL_DSN=
+
+E2E_TEST_BASE_URL=https://platform-acc.publiq.be/
+E2E_TEST_EMAIL=dev+e2etest@publiq.be
+E2E_TEST_PASSWORD=
+
+E2E_TEST_ADMIN_EMAIL=dev+e2etest-admin@publiq.be
+E2E_TEST_ADMIN_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -144,3 +144,11 @@ SLACK_BOT_TOKEN=
 SLACK_CHANNEL_ID=
 
 GTM_ID=
+
+E2E_TEST_BASE_URL=https://platform-acc.publiq.be/
+E2E_TEST_EMAIL=dev+e2etest@publiq.be
+E2E_TEST_PASSWORD=
+
+E2E_TEST_ADMIN_EMAIL=dev+e2etest-admin@publiq.be
+E2E_TEST_ADMIN_PASSWORD=
+

--- a/config/nova.php
+++ b/config/nova.php
@@ -90,7 +90,7 @@ return [
     'passwords' => env('NOVA_PASSWORDS', null),
 
     'users' => [
-        'dev+e2etest@publiq.be',
+        'dev+e2etest-admin@publiq.be',
         'simon.debruijn@publiq.be',
         'hande.vanhove@publiq.be',
         'luc@madewithlove.be',

--- a/e2e/setup/auth.setup.ts
+++ b/e2e/setup/auth.setup.ts
@@ -1,8 +1,29 @@
 import { test as setup } from "@playwright/test";
 
-const authFile = "playwright/.auth/user.json";
 
-setup("authenticate", async ({ page }) => {
+const adminFile = 'playwright/.auth/admin.json';
+
+setup('authenticate as admin', async ({ page }) => {
+  await page.goto("/nl");
+
+  await page.getByRole("link", { name: "Probeer gratis" }).click();
+
+  await page.waitForURL(/account-acc.uitid.be\/*/);
+
+  await page.getByLabel("Je e-mailadres").fill(process.env.E2E_TEST_ADMIN_EMAIL!);
+  await page.getByLabel("Je wachtwoord").fill(process.env.E2E_TEST_ADMIN_PASSWORD!);
+
+  await page.getByRole("button", { name: "Meld je aan", exact: true }).click();
+
+  await page.waitForLoadState("networkidle");
+  await page.waitForURL("/nl/integraties");
+
+  await page.context().storageState({ path: adminFile });
+});
+
+const userFile = "playwright/.auth/user.json";
+
+setup("authenticate as contributor", async ({ page }) => {
   await page.goto("/nl");
 
   await page.getByRole("link", { name: "Probeer gratis" }).click();
@@ -17,5 +38,5 @@ setup("authenticate", async ({ page }) => {
   await page.waitForLoadState("networkidle");
   await page.waitForURL("/nl/integraties");
 
-  await page.context().storageState({ path: authFile });
+  await page.context().storageState({ path: userFile });
 });

--- a/e2e/tests/integrations/create-integration-as-admin.test.ts
+++ b/e2e/tests/integrations/create-integration-as-admin.test.ts
@@ -6,11 +6,9 @@ test("create a new integration as an admin", async ({ page }) => {
   await page.goto("/admin");
   await page.getByRole("link", { name: "Integrations" }).click();
   await page.getByRole("link", { name: "Create Integration" }).click();
-  await page.getByPlaceholder("Name").click();
   await page.getByPlaceholder("Name").fill("Test E2E integration as admin");
   await page.locator("#type").selectOption("entry-api");
   await page.locator("#key_visibility").selectOption("all");
-  await page.getByPlaceholder("Description").click();
   await page
     .getByPlaceholder("Description")
     .fill("Test E2E integration as admin");

--- a/e2e/tests/integrations/create-integration-as-admin.test.ts
+++ b/e2e/tests/integrations/create-integration-as-admin.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test("create a new integration as an admin", async ({ page }) => {
+  await page.goto("/admin");
+  await page.getByRole("link", { name: "Integrations" }).click();
+  await page.getByRole("link", { name: "Create Integration" }).click();
+  await page.getByPlaceholder("Name").click();
+  await page.getByPlaceholder("Name").fill("Test E2E integration as admin");
+  await page.locator("#type").selectOption("entry-api");
+  await page.locator("#key_visibility").selectOption("all");
+  await page.getByPlaceholder("Description").click();
+  await page
+    .getByPlaceholder("Description")
+    .fill("Test E2E integration as admin");
+  await page
+    .getByTestId("subscriptions")
+    .selectOption("b46745a1-feb5-45fd-8fa9-8e3ef25aac26");
+  await page.getByRole("button", { name: "Create Integration" }).click();
+  await page
+    .getByRole("heading", { name: "Integration Details: Test E2E" })
+    .click();
+  await expect(
+    page
+      .locator("h1")
+      .getByText("Integration Details: Test E2E integration as admin")
+  ).toBeVisible();
+});


### PR DESCRIPTION
### Added
- [E2E admin test user credentials](https://github.com/cultuurnet/publiq-platform/commit/29c13a0d398812d09619d477dc3cc5efef93c056)
- [admin login setup](https://github.com/cultuurnet/publiq-platform/commit/a0f96c532c4788734bc4985d8adcbd07418b9062)
- [test: create integration as an admin](https://github.com/cultuurnet/publiq-platform/commit/f807d292984eaa6e951bb235f39e078c3bb65ace)

### Changed
- Nova config: [Replace email with admin email](https://github.com/cultuurnet/publiq-platform/commit/e9f321590e36b0c9ee5cf57e3732774ca2276d5e)

Note: test will fail until the nova.config is deployed to acc.
You can locally test it by using the same credentials as the regular contributor

---
Ticket: https://jira.publiq.be/browse/PPF-344