### PR TITLE
PPF-347 - Add E2E test: As an admin I can create a new organization

### DIFF
--- a/e2e/tests/integrations/create-organization-as-admin.test.ts
+++ b/e2e/tests/integrations/create-organization-as-admin.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.use({ storageState: "playwright/.auth/user.json" });
+test.use({ storageState: "playwright/.auth/admin.json" });
 
 test("As an admin I can create a new organization", async ({ page }) => {
   await page.goto("/admin");

--- a/e2e/tests/integrations/create-organization-as-admin.test.ts
+++ b/e2e/tests/integrations/create-organization-as-admin.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ storageState: "playwright/.auth/user.json" });
+
+test("As an admin I can create a new organization", async ({ page }) => {
+  await page.goto("/admin");
+  await page.getByRole("link", { name: "Organizations" }).click();
+  await page.getByRole("link", { name: "Create Organization" }).click();
+  await page.getByPlaceholder("Name").fill("E2E test organization");
+  await page.getByPlaceholder("Street").fill("test street 21");
+  await page.getByPlaceholder("City").fill("Brussels");
+  await page.getByPlaceholder("Zip").fill("1080");
+  await page.getByPlaceholder("Country").fill("Belgium");
+  await page
+    .getByPlaceholder("Invoice Email")
+    .fill(process.env.E2E_TEST_ADMIN_EMAIL!);
+  await page.getByPlaceholder("Vat").fill("BE 0475 250 609");
+  await page.getByRole("button", { name: "Create Organization" }).click();
+  await expect(
+    page
+      .locator("h1")
+      .getByText("Organization Details: E2E test organization")
+  ).toBeVisible();
+});


### PR DESCRIPTION
### Added
- [E2E test: As an admin I can create a new organization](https://github.com/cultuurnet/publiq-platform/commit/120900d9ba2c23c844c6ef63fa7236977231e552)

---
Ticket: https://jira.uitdatabank.be/browse/PPF-347
