### PR TITLE
Add timeout to project aanvraag client

### DIFF
--- a/app/Auth0/Listeners/CreateClients.php
+++ b/app/Auth0/Listeners/CreateClients.php
@@ -27,13 +27,13 @@ final class CreateClients implements ShouldQueue
 
     public function handle(IntegrationCreated $integrationCreated): void
     {
-        $integration = $this->integrationRepository->getById($integrationCreated->integrationId);
+        $integration = $this->integrationRepository->getById($integrationCreated->id);
         $auth0Clients = $this->auth0ClusterSDK->createClientsForIntegration($integration);
         $this->auth0ClientRepository->save(...$auth0Clients);
 
         foreach ($auth0Clients as $auth0Client) {
             $this->logger->info('Auth0 client created', [
-                'integration_id' => $integrationCreated->integrationId->toString(),
+                'integration_id' => $integrationCreated->id->toString(),
                 'tenant' => $auth0Client->tenant->value,
                 'client_id' => $auth0Client->clientId,
             ]);
@@ -43,7 +43,7 @@ final class CreateClients implements ShouldQueue
     public function failed(IntegrationCreated $integrationCreated, Throwable $throwable): void
     {
         $this->logger->error('Failed to create Auth0 client(s)', [
-            'integration_id' => $integrationCreated->integrationId->toString(),
+            'integration_id' => $integrationCreated->id->toString(),
             'exception' => $throwable,
         ]);
     }

--- a/app/Domain/Integrations/Events/IntegrationCreated.php
+++ b/app/Domain/Integrations/Events/IntegrationCreated.php
@@ -11,7 +11,7 @@ final class IntegrationCreated
 {
     use Dispatchable;
 
-    public function __construct(public readonly UuidInterface $integrationId)
+    public function __construct(public readonly UuidInterface $id)
     {
     }
 }

--- a/app/Insightly/Listeners/CreateOpportunity.php
+++ b/app/Insightly/Listeners/CreateOpportunity.php
@@ -33,12 +33,12 @@ final class CreateOpportunity implements ShouldQueue
 
     public function handle(IntegrationCreated $integrationCreated): void
     {
-        $integration = $this->integrationRepository->getById($integrationCreated->integrationId);
+        $integration = $this->integrationRepository->getById($integrationCreated->id);
 
         $insightlyId = $this->insightlyClient->opportunities()->create($integration);
 
         $this->insightlyMappingRepository->save(new InsightlyMapping(
-            $integrationCreated->integrationId,
+            $integrationCreated->id,
             $insightlyId,
             ResourceType::Opportunity
         ));
@@ -59,7 +59,7 @@ final class CreateOpportunity implements ShouldQueue
             'Opportunity created for integration',
             [
                 'domain' => 'insightly',
-                'integration_id' => $integrationCreated->integrationId->toString(),
+                'integration_id' => $integrationCreated->id->toString(),
             ]
         );
     }
@@ -70,7 +70,7 @@ final class CreateOpportunity implements ShouldQueue
             'Failed to create opportunity for integration',
             [
                 'domain' => 'insightly',
-                'integration_id' => $integrationCreated->integrationId->toString(),
+                'integration_id' => $integrationCreated->id->toString(),
                 'exception' => $exception,
             ]
         );

--- a/app/ProjectAanvraag/Listeners/CreateWidget.php
+++ b/app/ProjectAanvraag/Listeners/CreateWidget.php
@@ -149,14 +149,8 @@ final class CreateWidget implements ShouldQueue
             ConsumerCreated::class => 'consumer',
         };
 
-        $id = match (get_class($event)) {
-            IntegrationCreated::class => $event->integrationId->toString(),
-            ContactCreated::class => $event->id->toString(),
-            ConsumerCreated::class => $event->id->toString(),
-        };
-
-        $this->logger->error("Failed to create $entity", [
-            "{$entity}_id" => $id,
+        $this->logger->error('Failed to create widget', [
+            "{$entity}_id" => $event->id->toString(),
             'exception' => $throwable,
         ]);
     }

--- a/app/ProjectAanvraag/Listeners/CreateWidget.php
+++ b/app/ProjectAanvraag/Listeners/CreateWidget.php
@@ -20,6 +20,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
+use Throwable;
 
 final class CreateWidget implements ShouldQueue
 {
@@ -138,5 +139,13 @@ final class CreateWidget implements ShouldQueue
                 $liveKey
             )
         );
+    }
+
+    public function failed(ContactCreated $contactCreated, Throwable $throwable): void
+    {
+        $this->logger->error('Failed to create contact', [
+            'contact_id' => $contactCreated->id->toString(),
+            'exception' => $throwable,
+        ]);
     }
 }

--- a/app/ProjectAanvraag/Listeners/CreateWidget.php
+++ b/app/ProjectAanvraag/Listeners/CreateWidget.php
@@ -39,7 +39,7 @@ final class CreateWidget implements ShouldQueue
 
     public function handleIntegrationCreated(IntegrationCreated $integrationCreated): void
     {
-        $this->handle($integrationCreated->integrationId);
+        $this->handle($integrationCreated->id);
     }
 
     public function handleContactCreated(ContactCreated $contactCreated): void

--- a/app/ProjectAanvraag/Listeners/CreateWidget.php
+++ b/app/ProjectAanvraag/Listeners/CreateWidget.php
@@ -141,10 +141,22 @@ final class CreateWidget implements ShouldQueue
         );
     }
 
-    public function failed(ContactCreated $contactCreated, Throwable $throwable): void
+    public function failed(IntegrationCreated|ContactCreated|ConsumerCreated $event, Throwable $throwable): void
     {
-        $this->logger->error('Failed to create contact', [
-            'contact_id' => $contactCreated->id->toString(),
+        $entity = match (get_class($event)) {
+            IntegrationCreated::class => 'integration',
+            ContactCreated::class => 'contact',
+            ConsumerCreated::class => 'consumer',
+        };
+
+        $id = match (get_class($event)) {
+            IntegrationCreated::class => $event->integrationId->toString(),
+            ContactCreated::class => $event->id->toString(),
+            ConsumerCreated::class => $event->id->toString(),
+        };
+
+        $this->logger->error("Failed to create $entity", [
+            "$entity.id" => $id,
             'exception' => $throwable,
         ]);
     }

--- a/app/ProjectAanvraag/Listeners/CreateWidget.php
+++ b/app/ProjectAanvraag/Listeners/CreateWidget.php
@@ -156,7 +156,7 @@ final class CreateWidget implements ShouldQueue
         };
 
         $this->logger->error("Failed to create $entity", [
-            "$entity.id" => $id,
+            "{$entity}_id" => $id,
             'exception' => $throwable,
         ]);
     }

--- a/app/ProjectAanvraag/ProjectAanvraagClient.php
+++ b/app/ProjectAanvraag/ProjectAanvraagClient.php
@@ -26,7 +26,7 @@ final readonly class ProjectAanvraagClient
      */
     public function createWidget(CreateWidgetRequest $createWidgetRequest): void
     {
-        $baseUri = ProjectAanvraagUrl::getStatusBaseUri($createWidgetRequest->status);
+        $baseUri = ProjectAanvraagUrl::getBaseUrlForIntegrationStatus($createWidgetRequest->status);
         $request = new Request(
             'POST',
             $baseUri . '/project/' . $createWidgetRequest->integrationId->toString(),

--- a/app/ProjectAanvraag/ProjectAanvraagServiceProvider.php
+++ b/app/ProjectAanvraag/ProjectAanvraagServiceProvider.php
@@ -12,17 +12,27 @@ use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\ProjectAanvraag\Listeners\CreateWidget;
 use App\UiTiDv1\Events\ConsumerCreated;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Psr\Log\LoggerInterface;
+use GuzzleHttp\Client;
 
 final class ProjectAanvraagServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
         $this->app->singleton(ProjectAanvraagClient::class, function () {
+            $httpClient = new Client(
+                [
+                  RequestOptions::HTTP_ERRORS => false,
+                  RequestOptions::TIMEOUT => config('project_aanvraag.connect_timeout'),
+              ]
+            );
+
             return new ProjectAanvraagClient(
-                $this->app->get(LoggerInterface::class)
+                $this->app->get(LoggerInterface::class),
+                $httpClient
             );
         });
 

--- a/app/ProjectAanvraag/ProjectAanvraagServiceProvider.php
+++ b/app/ProjectAanvraag/ProjectAanvraagServiceProvider.php
@@ -26,7 +26,7 @@ final class ProjectAanvraagServiceProvider extends ServiceProvider
             $httpClient = new Client(
                 [
                   RequestOptions::HTTP_ERRORS => false,
-                  RequestOptions::TIMEOUT => config('project_aanvraag.connect_timeout'),
+                  RequestOptions::TIMEOUT => config('project_aanvraag.timeout'),
               ]
             );
 

--- a/app/ProjectAanvraag/ProjectAanvraagUrl.php
+++ b/app/ProjectAanvraag/ProjectAanvraagUrl.php
@@ -17,7 +17,7 @@ final class ProjectAanvraagUrl
         return self::getBaseUrlForIntegrationStatus($integration->status) . 'project/' . $integration->id . '/widget/?idToken=' . $idToken;
     }
 
-    public static function getBaseUrlForIntegrationStatus(IntegrationStatus $integrationStatus): mixed
+    public static function getBaseUrlForIntegrationStatus(IntegrationStatus $integrationStatus): string
     {
         $stage = $integrationStatus === IntegrationStatus::Active ? 'live' : 'test';
 

--- a/app/ProjectAanvraag/ProjectAanvraagUrl.php
+++ b/app/ProjectAanvraag/ProjectAanvraagUrl.php
@@ -14,10 +14,10 @@ final class ProjectAanvraagUrl
     {
         $idToken = Session::get('id_token');
 
-        return self::getStatusBaseUri($integration->status) . 'project/' . $integration->id . '/widget/?idToken=' . $idToken;
+        return self::getBaseUrlForIntegrationStatus($integration->status) . 'project/' . $integration->id . '/widget/?idToken=' . $idToken;
     }
 
-    public static function getStatusBaseUri(IntegrationStatus $integrationStatus): mixed
+    public static function getBaseUrlForIntegrationStatus(IntegrationStatus $integrationStatus): mixed
     {
         $stage = $integrationStatus === IntegrationStatus::Active ? 'live' : 'test';
 

--- a/app/UiTiDv1/Listeners/CreateConsumers.php
+++ b/app/UiTiDv1/Listeners/CreateConsumers.php
@@ -29,7 +29,7 @@ final class CreateConsumers implements ShouldQueue
 
     public function handle(IntegrationCreated $integrationCreated): void
     {
-        $integration = $this->integrationRepository->getById($integrationCreated->integrationId);
+        $integration = $this->integrationRepository->getById($integrationCreated->id);
         $consumers = $this->clusterSDK->createConsumersForIntegration($integration);
         $this->consumerRepository->save(...$consumers);
 
@@ -37,7 +37,7 @@ final class CreateConsumers implements ShouldQueue
             Event::dispatch(new ConsumerCreated($consumer->id));
 
             $this->logger->info('UiTiD v1 consumer created', [
-                'integration_id' => $integrationCreated->integrationId->toString(),
+                'integration_id' => $integrationCreated->id->toString(),
                 'tenant' => $consumer->environment->value,
                 'consumer_id' => $consumer->consumerId,
                 'consumer_key' => $consumer->consumerKey,
@@ -48,7 +48,7 @@ final class CreateConsumers implements ShouldQueue
     public function failed(IntegrationCreated $integrationCreated, Throwable $throwable): void
     {
         $this->logger->error('Failed to create UiTiD v1 consumer(s)', [
-            'integration_id' => $integrationCreated->integrationId->toString(),
+            'integration_id' => $integrationCreated->id->toString(),
             'exception' => $throwable,
         ]);
     }

--- a/config/project_aanvraag.php
+++ b/config/project_aanvraag.php
@@ -8,5 +8,5 @@ return [
         'test' => env('PROJECT_AANVRAAG_BASE_URI_TEST', 'http://localhost/'),
         'live' => env('PROJECT_AANVRAAG_BASE_URI_LIVE', 'http://localhost/'),
     ],
-    'connect_timeout' => env('PROJECT_AANVRAAG_CONNECT_TIMEOUT', 10.0),
+    'timeout' => env('PROJECT_AANVRAAG_TIMEOUT', 10.0),
 ];

--- a/config/project_aanvraag.php
+++ b/config/project_aanvraag.php
@@ -8,5 +8,5 @@ return [
         'test' => env('PROJECT_AANVRAAG_BASE_URI_TEST', 'http://localhost/'),
         'live' => env('PROJECT_AANVRAAG_BASE_URI_LIVE', 'http://localhost/'),
     ],
-    'connect_timeout' => env('PROJECT_AANVRAAG_CONNECT_TIMEOUT', 10.0)
+    'connect_timeout' => env('PROJECT_AANVRAAG_CONNECT_TIMEOUT', 10.0),
 ];

--- a/config/project_aanvraag.php
+++ b/config/project_aanvraag.php
@@ -8,4 +8,5 @@ return [
         'test' => env('PROJECT_AANVRAAG_BASE_URI_TEST', 'http://localhost/'),
         'live' => env('PROJECT_AANVRAAG_BASE_URI_LIVE', 'http://localhost/'),
     ],
+    'connect_timeout' => env('PROJECT_AANVRAAG_CONNECT_TIMEOUT', 10.0)
 ];

--- a/tests/ProjectAanvraag/Listeners/CreateWidgetTest.php
+++ b/tests/ProjectAanvraag/Listeners/CreateWidgetTest.php
@@ -17,6 +17,7 @@ use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Json;
 use App\ProjectAanvraag\Listeners\CreateWidget;
 use App\ProjectAanvraag\ProjectAanvraagClient;
+use App\ProjectAanvraag\ProjectAanvraagUrl;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
 use App\UiTiDv1\UiTiDv1Consumer;
 use App\UiTiDv1\UiTiDv1Environment;
@@ -113,7 +114,7 @@ final class CreateWidgetTest extends TestCase
 
         $expectedRequest = new Request(
             'POST',
-            'projects',
+            ProjectAanvraagUrl::getStatusBaseUri($integration->status) . '/projects',
             [],
             Json::encode([
                 'userId' => 'google-oauth2|102486314601596809843',

--- a/tests/ProjectAanvraag/Listeners/CreateWidgetTest.php
+++ b/tests/ProjectAanvraag/Listeners/CreateWidgetTest.php
@@ -114,7 +114,7 @@ final class CreateWidgetTest extends TestCase
 
         $expectedRequest = new Request(
             'POST',
-            ProjectAanvraagUrl::getStatusBaseUri($integration->status) . '/projects',
+            ProjectAanvraagUrl::getBaseUrlForIntegrationStatus($integration->status) . '/projects',
             [],
             Json::encode([
                 'userId' => 'google-oauth2|102486314601596809843',


### PR DESCRIPTION
Make sure time out to projectaanvraag throws exception and gets logged.
When running locally without having projectaanvraag docker running the create contact request would load endlessly

### Added
- [Add connect_timeout config option](https://github.com/cultuurnet/publiq-platform/commit/210310838c4b9f54b0adf57859ba1c85d6c0d5e8)
- [Add failed method on CreateWidget listener](https://github.com/cultuurnet/publiq-platform/commit/1b78a46e0c41d9cd6aa71c39590a616b60f4fd81)

### Changed
- [Configure httpClient in provider](https://github.com/cultuurnet/publiq-platform/commit/8a2168d0a6612b9f1fa9981c7be2084c92d2ff80)

![Screenshot 2024-03-26 at 15 09 24](https://github.com/cultuurnet/publiq-platform/assets/66943525/eefd2fd5-e223-4dd0-828e-4ac98d054801)
