### PR TITLE
Add missing type

### DIFF
--- a/app/Insightly/Listeners/ActivateProject.php
+++ b/app/Insightly/Listeners/ActivateProject.php
@@ -229,7 +229,7 @@ final class ActivateProject implements ShouldQueue
     }
 
     public function failed(
-        IntegrationActivated $integrationActivated,
+        IntegrationActivated|IntegrationActivationRequested $integrationActivated,
         Throwable $exception
     ): void {
         $this->logger->error(


### PR DESCRIPTION
### Fixed
- Avoid a crash by adding a missing type on the failed method of `ActivateProject`
