### PR TITLE
PPF-376 Add endpoint to request key visibility upgrade

### DIFF
--- a/app/Domain/Integrations/Controllers/IntegrationController.php
+++ b/app/Domain/Integrations/Controllers/IntegrationController.php
@@ -13,6 +13,7 @@ use App\Domain\Coupons\Repositories\CouponRepository;
 use App\Domain\Integrations\FormRequests\RequestActivationRequest;
 use App\Domain\Integrations\FormRequests\StoreIntegrationRequest;
 use App\Domain\Integrations\FormRequests\StoreIntegrationUrlRequest;
+use App\Domain\Integrations\FormRequests\KeyVisibilityUpgradeRequest;
 use App\Domain\Integrations\FormRequests\UpdateContactInfoRequest;
 use App\Domain\Integrations\FormRequests\UpdateIntegrationRequest;
 use App\Domain\Integrations\FormRequests\UpdateIntegrationUrlsRequest;
@@ -24,6 +25,7 @@ use App\Domain\Integrations\KeyVisibility;
 use App\Domain\Integrations\Mappers\OrganizationMapper;
 use App\Domain\Integrations\Mappers\StoreIntegrationMapper;
 use App\Domain\Integrations\Mappers\StoreIntegrationUrlMapper;
+use App\Domain\Integrations\Mappers\KeyVisibilityUpgradeMapper;
 use App\Domain\Integrations\Mappers\UpdateContactInfoMapper;
 use App\Domain\Integrations\Mappers\UpdateIntegrationMapper;
 use App\Domain\Integrations\Mappers\UpdateIntegrationUrlsMapper;
@@ -31,6 +33,7 @@ use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Domain\Integrations\Repositories\IntegrationUrlRepository;
 use App\Domain\Organizations\Repositories\OrganizationRepository;
 use App\Domain\Subscriptions\Repositories\SubscriptionRepository;
+use App\Domain\KeyVisibilityUpgrades\Repositories\KeyVisibilityUpgradeRepository;
 use App\Http\Controllers\Controller;
 use App\ProjectAanvraag\ProjectAanvraagUrl;
 use App\Router\TranslatedRoute;
@@ -58,6 +61,7 @@ final class IntegrationController extends Controller
         private readonly CouponRepository $couponRepository,
         private readonly Auth0ClientRepository $auth0ClientRepository,
         private readonly UiTiDv1ConsumerRepository $uitidV1ConsumerRepository,
+        private readonly KeyVisibilityUpgradeRepository $keyVisibilityUpgradeRepository,
         private readonly CurrentUser $currentUser
     ) {
     }
@@ -248,6 +252,15 @@ final class IntegrationController extends Controller
     {
         $integration = $this->integrationRepository->getById(Uuid::fromString($id));
         return redirect()->away(ProjectAanvraagUrl::getForIntegration($integration));
+    }
+
+    public function storeKeyVisibilityUpgrade(string $id, KeyVisibilityUpgradeRequest $request): RedirectResponse
+    {
+        $this->keyVisibilityUpgradeRepository->save(KeyVisibilityUpgradeMapper::map($request, Uuid::fromString($id)));
+
+        return Redirect::route(
+            TranslatedRoute::getTranslatedRouteName($request, 'integrations.index')
+        );
     }
 
     private function getKeyVisibility(Integration $integration): KeyVisibility

--- a/app/Domain/Integrations/FormRequests/KeyVisibilityUpgradeRequest.php
+++ b/app/Domain/Integrations/FormRequests/KeyVisibilityUpgradeRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\FormRequests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class KeyVisibilityUpgradeRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'keyVisibility' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Domain/Integrations/IntegrationServiceProvider.php
+++ b/app/Domain/Integrations/IntegrationServiceProvider.php
@@ -6,10 +6,12 @@ namespace App\Domain\Integrations;
 
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Listeners\ActivateIntegration;
+use App\Domain\Integrations\Listeners\UpgradeKeyVisibility;
 use App\Domain\Integrations\Repositories\EloquentIntegrationRepository;
 use App\Domain\Integrations\Repositories\EloquentIntegrationUrlRepository;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Domain\Integrations\Repositories\IntegrationUrlRepository;
+use App\Domain\KeyVisibilityUpgrades\Events\KeyVisibilityUpgradeCreated;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -21,5 +23,6 @@ final class IntegrationServiceProvider extends ServiceProvider
         $this->app->bind(IntegrationUrlRepository::class, EloquentIntegrationUrlRepository::class);
 
         Event::listen(IntegrationCreated::class, [ActivateIntegration::class, 'handle']);
+        Event::listen(KeyVisibilityUpgradeCreated::class, [UpgradeKeyVisibility::class, 'handle']);
     }
 }

--- a/app/Domain/Integrations/Listeners/UpgradeKeyVisibility.php
+++ b/app/Domain/Integrations/Listeners/UpgradeKeyVisibility.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Listeners;
+
+use App\Domain\Integrations\KeyVisibility;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\Domain\KeyVisibilityUpgrades\Events\KeyVisibilityUpgradeCreated;
+use App\Domain\KeyVisibilityUpgrades\Repositories\KeyVisibilityUpgradeRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+final class UpgradeKeyVisibility implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly KeyVisibilityUpgradeRepository $keyVisibilityUpgradeRepository
+    ) {
+    }
+
+    public function handle(KeyVisibilityUpgradeCreated $keyVisibilityUpgradeCreated): void
+    {
+        $keyVisibilityUpgrade = $this->keyVisibilityUpgradeRepository->getById($keyVisibilityUpgradeCreated->id);
+
+        $integration = $this->integrationRepository->getById($keyVisibilityUpgrade->integrationId);
+
+        // For now there is only an upgrade possible from v1 to v2, so all can be used.
+        $this->integrationRepository->update($integration->withKeyVisibility(KeyVisibility::all));
+    }
+}

--- a/app/Domain/Integrations/Mappers/KeyVisibilityUpgradeMapper.php
+++ b/app/Domain/Integrations/Mappers/KeyVisibilityUpgradeMapper.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Mappers;
+
+use App\Domain\Integrations\FormRequests\KeyVisibilityUpgradeRequest;
+use App\Domain\Integrations\KeyVisibility;
+use App\Domain\KeyVisibilityUpgrades\KeyVisibilityUpgrade;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+final class KeyVisibilityUpgradeMapper
+{
+    public static function map(KeyVisibilityUpgradeRequest $request, UuidInterface $integrationId): KeyVisibilityUpgrade
+    {
+        return new KeyVisibilityUpgrade(
+            Uuid::uuid4(),
+            $integrationId,
+            KeyVisibility::from($request->input('keyVisibility'))
+        );
+    }
+}

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -37,6 +37,7 @@ final class EloquentIntegrationRepository implements IntegrationRepository
             'subscription_id' => $integration->subscriptionId,
             'status' => $integration->status,
             'partner_status' => $integration->partnerStatus,
+            'key_visibility' => $integration->getKeyVisibility(),
         ]);
     }
 

--- a/app/Domain/KeyVisibilityUpgrades/Events/KeyVisibilityUpgradeCreated.php
+++ b/app/Domain/KeyVisibilityUpgrades/Events/KeyVisibilityUpgradeCreated.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyVisibilityUpgrades\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Ramsey\Uuid\UuidInterface;
+
+final class KeyVisibilityUpgradeCreated
+{
+    use Dispatchable;
+
+    public function __construct(public readonly UuidInterface $id)
+    {
+    }
+}

--- a/app/Domain/KeyVisibilityUpgrades/KeyVisibilityUpgrade.php
+++ b/app/Domain/KeyVisibilityUpgrades/KeyVisibilityUpgrade.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyVisibilityUpgrades;
+
+use App\Domain\Integrations\KeyVisibility;
+use Ramsey\Uuid\UuidInterface;
+
+final readonly class KeyVisibilityUpgrade
+{
+    public function __construct(
+        public UuidInterface $id,
+        public UuidInterface $integrationId,
+        public KeyVisibility $keyVisibility
+    ) {
+    }
+}

--- a/app/Domain/KeyVisibilityUpgrades/Models/KeyVisibilityUpgradeModel.php
+++ b/app/Domain/KeyVisibilityUpgrades/Models/KeyVisibilityUpgradeModel.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyVisibilityUpgrades\Models;
+
+use App\Domain\Integrations\KeyVisibility;
+use App\Domain\Integrations\Models\IntegrationModel;
+use App\Domain\KeyVisibilityUpgrades\Events\KeyVisibilityUpgradeCreated;
+use App\Domain\KeyVisibilityUpgrades\KeyVisibilityUpgrade;
+use App\Models\UuidModel;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Ramsey\Uuid\Uuid;
+
+final class KeyVisibilityUpgradeModel extends UuidModel
+{
+    use SoftDeletes;
+
+    protected $table = 'key_visibility_upgrades';
+
+    protected $fillable = [
+        'id',
+        'integration_id',
+        'key_visibility',
+    ];
+
+    protected static function booted(): void
+    {
+        self::created(
+            static fn (KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel)
+                => KeyVisibilityUpgradeCreated::dispatch(Uuid::fromString($keyVisibilityUpgradeModel->id))
+        );
+    }
+
+    /**
+     * @return BelongsTo<IntegrationModel, KeyVisibilityUpgradeModel>
+     */
+    public function integration(): BelongsTo
+    {
+        return $this->belongsTo(IntegrationModel::class, 'integration_id');
+    }
+
+    public function toDomain(): KeyVisibilityUpgrade
+    {
+        return new KeyVisibilityUpgrade(
+            Uuid::fromString($this->id),
+            Uuid::fromString($this->integration_id),
+            KeyVisibility::from($this->key_visibility)
+        );
+    }
+}

--- a/app/Domain/KeyVisibilityUpgrades/Policies/KeyVisibilityUpgradePolicy.php
+++ b/app/Domain/KeyVisibilityUpgrades/Policies/KeyVisibilityUpgradePolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyVisibilityUpgrades\Policies;
+
+use App\Domain\Auth\Models\UserModel;
+use App\Domain\KeyVisibilityUpgrades\Models\KeyVisibilityUpgradeModel;
+
+final class KeyVisibilityUpgradePolicy
+{
+    public function viewAny(UserModel $userModel): bool
+    {
+        return true;
+    }
+
+    public function view(UserModel $userModel, KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel): bool
+    {
+        return true;
+    }
+
+    public function create(UserModel $userModel): bool
+    {
+        return true;
+    }
+
+    public function update(UserModel $userModel, KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel): bool
+    {
+        return true;
+    }
+
+    public function delete(UserModel $userModel, KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel): bool
+    {
+        return true;
+    }
+
+    public function restore(UserModel $userModel, KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel): bool
+    {
+        return false;
+    }
+
+    public function replicate(UserModel $userModel, KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel): bool
+    {
+        return false;
+    }
+
+    public function forceDelete(UserModel $userModel, KeyVisibilityUpgradeModel $keyVisibilityUpgradeModel): bool
+    {
+        return false;
+    }
+}

--- a/app/Domain/KeyVisibilityUpgrades/Repositories/EloquentKeyVisibilityUpgradeRepository.php
+++ b/app/Domain/KeyVisibilityUpgrades/Repositories/EloquentKeyVisibilityUpgradeRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyVisibilityUpgrades\Repositories;
+
+use App\Domain\KeyVisibilityUpgrades\Models\KeyVisibilityUpgradeModel;
+use App\Domain\KeyVisibilityUpgrades\KeyVisibilityUpgrade;
+use Ramsey\Uuid\UuidInterface;
+
+final class EloquentKeyVisibilityUpgradeRepository implements KeyVisibilityUpgradeRepository
+{
+    public function save(KeyVisibilityUpgrade $keyVisibilityUpgrade): void
+    {
+        KeyVisibilityUpgradeModel::query()->create(
+            [
+                'id' => $keyVisibilityUpgrade->id->toString(),
+                'integration_id' => $keyVisibilityUpgrade->integrationId->toString(),
+                'key_visibility' => $keyVisibilityUpgrade->keyVisibility->value,
+            ]
+        );
+    }
+
+    public function getById(UuidInterface $id): KeyVisibilityUpgrade
+    {
+        /** @var KeyVisibilityUpgradeModel $keyVisibilityUpgrade */
+        $keyVisibilityUpgrade = KeyVisibilityUpgradeModel::query()->findOrFail($id->toString());
+        return $keyVisibilityUpgrade->toDomain();
+    }
+}

--- a/app/Domain/KeyVisibilityUpgrades/Repositories/KeyVisibilityUpgradeRepository.php
+++ b/app/Domain/KeyVisibilityUpgrades/Repositories/KeyVisibilityUpgradeRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyVisibilityUpgrades\Repositories;
+
+use App\Domain\KeyVisibilityUpgrades\KeyVisibilityUpgrade;
+use Ramsey\Uuid\UuidInterface;
+
+interface KeyVisibilityUpgradeRepository
+{
+    public function save(KeyVisibilityUpgrade $keyVisibilityUpgrade): void;
+
+    public function getById(UuidInterface $id): KeyVisibilityUpgrade;
+}

--- a/app/Nova/Resources/KeyVisibilityUpgrade.php
+++ b/app/Nova/Resources/KeyVisibilityUpgrade.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Resources;
+
+use App\Domain\Integrations\KeyVisibility;
+use App\Domain\KeyVisibilityUpgrades\Models\KeyVisibilityUpgradeModel;
+use App\Nova\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+/**
+ * @mixin KeyVisibilityUpgradeModel
+ */
+final class KeyVisibilityUpgrade extends Resource
+{
+    public static string $model = KeyVisibilityUpgradeModel::class;
+
+    public static function indexQuery(NovaRequest $request, $query): Builder
+    {
+        return parent::indexQuery($request, $query)
+            ->select('key_visibility_upgrades.*')
+            ->leftJoin('integrations', 'integration_id', '=', 'integrations.id');
+    }
+
+    /**
+     * @return array<Field>
+     */
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            ID::make()
+                ->readonly()
+                ->hideFromIndex(),
+
+            BelongsTo::make('Integration')
+                ->sortable()
+                ->withMeta(['sortableUriKey' => 'integrations.name'])
+                ->withoutTrashed()
+                ->readonly(fn (NovaRequest $request) => $request->isUpdateOrUpdateAttachedRequest())
+                ->rules('required'),
+
+            Select::make('Key Visibility')
+                ->filterable()
+                ->sortable()
+                ->options([
+                    KeyVisibility::v2->value => KeyVisibility::v2->name,
+                ])
+                ->rules('required'),
+
+            DateTime::make('Created At')
+                ->readonly()
+                ->hideWhenCreating()
+                ->hideWhenUpdating(),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,8 @@ use App\Domain\Contacts\Repositories\EloquentContactKeyVisibilityRepository;
 use App\Domain\Contacts\Repositories\EloquentContactRepository;
 use App\Domain\Coupons\Repositories\CouponRepository;
 use App\Domain\Coupons\Repositories\EloquentCouponRepository;
+use App\Domain\KeyVisibilityUpgrades\Repositories\EloquentKeyVisibilityUpgradeRepository;
+use App\Domain\KeyVisibilityUpgrades\Repositories\KeyVisibilityUpgradeRepository;
 use App\Domain\Organizations\Repositories\EloquentOrganizationRepository;
 use App\Domain\Organizations\Repositories\OrganizationRepository;
 use App\Domain\Subscriptions\Repositories\EloquentSubscriptionRepository;
@@ -25,5 +27,6 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->bind(CouponRepository::class, EloquentCouponRepository::class);
         $this->app->bind(OrganizationRepository::class, EloquentOrganizationRepository::class);
         $this->app->bind(SubscriptionRepository::class, EloquentSubscriptionRepository::class);
+        $this->app->bind(KeyVisibilityUpgradeRepository::class, EloquentKeyVisibilityUpgradeRepository::class);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -21,6 +21,8 @@ use App\Domain\Organizations\Models\OrganizationModel;
 use App\Domain\Organizations\Policies\OrganizationPolicy;
 use App\Domain\Subscriptions\Models\SubscriptionModel;
 use App\Domain\Subscriptions\Policies\SubscriptionPolicy;
+use App\Domain\KeyVisibilityUpgrades\Models\KeyVisibilityUpgradeModel;
+use App\Domain\KeyVisibilityUpgrades\Policies\KeyVisibilityUpgradePolicy;
 use App\UiTiDv1\Models\UiTiDv1ConsumerModel;
 use App\UiTiDv1\Policies\UiTiDv1ConsumerPolicy;
 use Auth0\SDK\Auth0;
@@ -41,6 +43,7 @@ final class AuthServiceProvider extends ServiceProvider
         SubscriptionModel::class => SubscriptionPolicy::class,
         UiTiDv1ConsumerModel::class => UiTiDv1ConsumerPolicy::class,
         Auth0ClientModel::class => Auth0ClientPolicy::class,
+        KeyVisibilityUpgradeModel::class => KeyVisibilityUpgradePolicy::class,
     ];
 
     public function boot(): void

--- a/database/migrations/2024_04_09_100641_create_key_visibility_upgrades_table.php
+++ b/database/migrations/2024_04_09_100641_create_key_visibility_upgrades_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('key_visibility_upgrades', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('integration_id');
+            $table->string('key_visibility');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('key_visibility_upgrades');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,5 +94,7 @@ Route::group(['middleware' => 'auth'], static function () {
         Route::post('/integrations/{id}/activation', [IntegrationController::class, 'requestActivation']);
 
         Route::get('/integrations/{id}/widget', [IntegrationController::class, 'showWidget']);
+
+        Route::post('/integrations/{id}/upgrade', [IntegrationController::class, 'storeKeyVisibilityUpgrade']);
     });
 });

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -13,6 +13,7 @@ use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\IntegrationPartnerStatus;
 use App\Domain\Integrations\IntegrationStatus;
 use App\Domain\Integrations\IntegrationType;
+use App\Domain\Integrations\KeyVisibility;
 use App\Domain\Integrations\Models\IntegrationModel;
 use App\Domain\Integrations\Repositories\EloquentIntegrationRepository;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -132,7 +133,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
 
         $this->integrationRepository->save($secondIntegration);
 
-        $updatedIntegration = new Integration(
+        $updatedIntegration = (new Integration(
             $initialIntegration->id,
             $initialIntegration->type,
             'Updated Integration',
@@ -140,7 +141,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             $initialIntegration->subscriptionId,
             IntegrationStatus::Active,
             $initialIntegration->partnerStatus,
-        );
+        ))->withKeyVisibility(KeyVisibility::all);
 
         $this->integrationRepository->update($updatedIntegration);
 

--- a/tests/Domain/KeyVisibilityUpgrades/Repositories/EloquentKeyVisibilityUpgradeRepositoryTest.php
+++ b/tests/Domain/KeyVisibilityUpgrades/Repositories/EloquentKeyVisibilityUpgradeRepositoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\KeyVisibilityUpgrades\Repositories;
+
+use App\Domain\Integrations\KeyVisibility;
+use App\Domain\KeyVisibilityUpgrades\Repositories\EloquentKeyVisibilityUpgradeRepository;
+use App\Domain\KeyVisibilityUpgrades\KeyVisibilityUpgrade;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Ramsey\Uuid\Uuid;
+use Tests\TestCase;
+
+final class EloquentKeyVisibilityUpgradeRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private EloquentKeyVisibilityUpgradeRepository $keyVisibilityUpgradeRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->keyVisibilityUpgradeRepository = new EloquentKeyVisibilityUpgradeRepository();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_key_visibility_upgrade(): void
+    {
+        $upgradeRequest = new KeyVisibilityUpgrade(
+            Uuid::uuid4(),
+            Uuid::uuid4(),
+            KeyVisibility::v2
+        );
+        $this->keyVisibilityUpgradeRepository->save($upgradeRequest);
+
+        $this->assertDatabaseHas('key_visibility_upgrades', [
+            'id' => $upgradeRequest->id->toString(),
+            'integration_id' => $upgradeRequest->integrationId->toString(),
+            'key_visibility' => $upgradeRequest->keyVisibility->value,
+        ]);
+    }
+}


### PR DESCRIPTION
### Added
- Added endpoint `POST /integrations/{integrationId}/upgrade` to request the upgrade from a v1 to v2 key.

### Note
- For now, only a v1 to v2 upgrade is possible and this results in key visibility of `all` of the integrations. If needed this can be abstracted out of the HTTP request.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-376
