### PR TITLE
PPF-391 - Add clarifying copy about functional and technical contacts

### DIFF
--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -99,7 +99,9 @@
     "aim": "Integration purpose",
     "description_aim": "Provide a clear, motivated description of the integration you want to set up with the publiq platform (max. 200 characters)",
     "contact_label_functional": "Functional contact",
+    "contact_label_functional_info": "The functional contact is the functional point of contact for the integration (e.g., an employee of the organization or municipality for which the integration is intended).",
     "contact_label_technical": "Technical contact",
+    "contact_label_technical_info": "The technical contact is the technical point of contact for the integration (e.g., the developer of the integration).",
     "contact_label_contributor": "Employee",
     "add": "Add employee",
     "contact": {

--- a/resources/translations/nl.json
+++ b/resources/translations/nl.json
@@ -99,7 +99,9 @@
     "aim": "Doel van de integratie",
     "description_aim": "Geef een duidelijke, gemotiveerde beschrijving van de integratie die je met het publiq platform wil opzetten (max. 200 karakters)",
     "contact_label_functional": "Inhoudelijk contact",
+    "contact_label_functional_info": "Het inhoudelijk contact is het inhoudelijk aanspreekpunt voor de integratie (bvb. een medewerker van de organisatie of gemeente waarvoor de integratie is).",
     "contact_label_technical": "Technisch contact",
+    "contact_label_technical_info": "Het technisch contact is het technische aanspreekpunt voor de integratie (bvb. de ontwikkelaar van de integratie).", 
     "contact_label_contributor": "Medewerker",
     "add": "Medewerker toevoegen",
     "contact": {

--- a/resources/ts/Pages/Integrations/New.tsx
+++ b/resources/ts/Pages/Integrations/New.tsx
@@ -249,7 +249,7 @@ const New = ({ subscriptions }: Props) => {
 
           <Card
             title={t("integration_form.contact_label_technical")}
-            contentStyles="flex flex-col gap-5 mb-5"
+            contentStyles="flex flex-col gap-5"
           >
             <div className="grid grid-cols-3 max-md:flex max-md:flex-col gap-5">
               <FormElement

--- a/resources/ts/Pages/Integrations/New.tsx
+++ b/resources/ts/Pages/Integrations/New.tsx
@@ -241,6 +241,9 @@ const New = ({ subscriptions }: Props) => {
                   error={errors.emailFunctionalContact}
                 />
               </div>
+              <span className="text-gray-500 text-sm">
+                {t("integration_form.contact_label_functional_info")}
+              </span>
             </div>
           </Card>
 
@@ -296,6 +299,9 @@ const New = ({ subscriptions }: Props) => {
                 error={errors.emailTechnicalContact}
               />
             </div>
+            <span className="text-gray-500 text-sm">
+              {t("integration_form.contact_label_technical_info")}
+            </span>
           </Card>
 
           <Card contentStyles="flex flex-col gap-5">


### PR DESCRIPTION
### Added
- [clarifying copy about functional and technical contacts](https://github.com/cultuurnet/publiq-platform/commit/4578b8e7c40bb6e2cb93068f99a83b5f7b04164d)

### Removed
- [unnecessary margin bottom](https://github.com/cultuurnet/publiq-platform/commit/bd6dac2386597325a8c2ae311b3e30839429b631)

Screenshot:
<img width="1203" alt="Screenshot 2024-04-15 at 11 27 06" src="https://github.com/cultuurnet/publiq-platform/assets/9402377/126771c2-f1a0-4e3f-b356-b72d0aaff26f">

---
Ticket: https://jira.uitdatabank.be/browse/PPF-391
