### PR TITLE
PPF-393- Disable browser validation so the form gets submitted and b…

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -178,6 +178,8 @@ return [
         'firstNamePartner' => 'first name',
         'lastNamePartner' => 'last name',
         'emailPartner' => 'email',
+        'functional.email' => 'email',
+        'technical.email' => 'email',
         'organization.name' => 'name',
         'organization.invoiceEmail' => 'email',
         'organization.address.street' => 'street',

--- a/lang/nl/validation.php
+++ b/lang/nl/validation.php
@@ -193,6 +193,8 @@ return [
         'lastNameTechnicalContact' => 'achternaam',
         'emailTechnicalContact' => 'email',
         'agreement' => 'gebruikersvoorwaarden',
+        'functional.email' => 'email',
+        'technical.email' => 'email',
         'organization.name' => 'naam',
         'organization.invoiceEmail' => 'email',
         'organization.address.street' => 'straat',

--- a/resources/ts/Components/Integrations/Detail/ContactInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/ContactInfo.tsx
@@ -153,19 +153,6 @@ export const ContactInfo = ({ id, contacts, isMobile }: Props) => {
     toBeEditedId,
   ]);
 
-  const editContactInfo = () => {
-    return new Promise((resolve, reject) => {
-      patch(`/integrations/${id}/contacts`, {
-        preserveScroll: true,
-        onError: (error) => reject(error),
-        onSuccess: () => {
-          setToBeEditedId("");
-          resolve(undefined);
-        },
-      });
-    });
-  };
-
   return (
     <>
       <div className="w-full flex flex-col gap-6">
@@ -283,8 +270,13 @@ export const ContactInfo = ({ id, contacts, isMobile }: Props) => {
                   {t("dialog.cancel")}
                 </ButtonSecondary>
                 <ButtonPrimary
-                  onClick={async () => {
-                    await editContactInfo();
+                  onClick={() => {
+                    patch(`/integrations/${id}/contacts`, {
+                      preserveScroll: true,
+                      onSuccess: () => {
+                        setToBeEditedId("");
+                      },
+                    });
                   }}
                 >
                   {t("dialog.confirm")}

--- a/resources/ts/Components/Integrations/Detail/ContactInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/ContactInfo.tsx
@@ -153,6 +153,19 @@ export const ContactInfo = ({ id, contacts, isMobile }: Props) => {
     toBeEditedId,
   ]);
 
+  const editContactInfo = () => {
+    return new Promise((resolve, reject) => {
+      patch(`/integrations/${id}/contacts`, {
+        preserveScroll: true,
+        onError: (error) => reject(error),
+        onSuccess: () => {
+          setToBeEditedId("");
+          resolve(undefined);
+        },
+      });
+    });
+  };
+
   return (
     <>
       <div className="w-full flex flex-col gap-6">
@@ -270,11 +283,8 @@ export const ContactInfo = ({ id, contacts, isMobile }: Props) => {
                   {t("dialog.cancel")}
                 </ButtonSecondary>
                 <ButtonPrimary
-                  onClick={() => {
-                    setToBeEditedId("");
-                    patch(`/integrations/${id}/contacts`, {
-                      preserveScroll: true,
-                    });
+                  onClick={async () => {
+                    await editContactInfo();
                   }}
                 >
                   {t("dialog.confirm")}

--- a/resources/ts/Pages/Integrations/New.tsx
+++ b/resources/ts/Pages/Integrations/New.tsx
@@ -96,7 +96,11 @@ const New = ({ subscriptions }: Props) => {
     <Page>
       <div className="inline-flex flex-col gap-5 w-full">
         <Heading level={2}>{t("integration_form.title")}</Heading>
-        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-7">
+        <form
+          onSubmit={handleSubmit}
+          noValidate
+          className="flex flex-col gap-7"
+        >
           <Card title={t("integration_form.type")}>
             <RadioButtonGroup
               orientation="vertical"

--- a/resources/ts/Pages/Integrations/New.tsx
+++ b/resources/ts/Pages/Integrations/New.tsx
@@ -96,7 +96,7 @@ const New = ({ subscriptions }: Props) => {
     <Page>
       <div className="inline-flex flex-col gap-5 w-full">
         <Heading level={2}>{t("integration_form.title")}</Heading>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-7">
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-7">
           <Card title={t("integration_form.type")}>
             <RadioButtonGroup
               orientation="vertical"


### PR DESCRIPTION
### Added
- [human readable label for functional & technical email](https://github.com/cultuurnet/publiq-platform/pull/1008/commits/943d3241501a0d4e6e8cb1c607fcd0da27ff9f4f)

### Changed
-  Disable browser validation so the form gets submitted and backend validation messages are shown

### Fixed
- [Make sure contactInfo modal only closes when there are no errors from the backend](https://github.com/cultuurnet/publiq-platform/pull/1008/commits/5163de17d62fb2ad9b85047947325dedd5572b19)

**Before:**
<img width="1139" alt="Screenshot 2024-04-15 at 13 47 48" src="https://github.com/cultuurnet/publiq-platform/assets/9402377/ee14fd3b-f460-4019-95cb-2a68bb5e080c">

**After:**
<img width="1165" alt="Screenshot 2024-04-15 at 13 47 26" src="https://github.com/cultuurnet/publiq-platform/assets/9402377/3f3ed594-ff47-4d20-95a6-387c693b0183">

<img width="771" alt="Screenshot 2024-04-15 at 14 39 11" src="https://github.com/cultuurnet/publiq-platform/assets/9402377/ca281577-088e-4468-9185-24e13ffe4439">

---
Ticket: https://jira.uitdatabank.be/browse/PPF-393
