### PR TITLE
PPF-429: add check to see if subscription already exists before seeding

### DIFF
--- a/app/Domain/Subscriptions/SubscriptionUuid.php
+++ b/app/Domain/Subscriptions/SubscriptionUuid.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Subscriptions;
 
-enum SubscriptionPlan: string
+enum SubscriptionUuid: string
 {
     case BASIC_SEARCH_API_PLAN = 'b46745a1-feb5-45fd-8fa9-8e3ef25aac26';
     case BASIC_WIDGETS_PLAN = 'c470ccbf-074c-4bf1-b526-47c94c5e9296';

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,7 +16,6 @@ final class DatabaseSeeder extends Seeder
 
         $this->call([
             SubscriptionsSeeder::class,
-            CouponsSeeder::class,
         ]);
     }
 }

--- a/database/seeders/SubscriptionUuid.php
+++ b/database/seeders/SubscriptionUuid.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Domain\Subscriptions;
+namespace Database\Seeders;
 
 enum SubscriptionUuid: string
 {

--- a/database/seeders/SubscriptionsSeeder.php
+++ b/database/seeders/SubscriptionsSeeder.php
@@ -9,7 +9,6 @@ use App\Domain\Subscriptions\Currency;
 use App\Domain\Subscriptions\Repositories\SubscriptionRepository;
 use App\Domain\Subscriptions\Subscription;
 use App\Domain\Subscriptions\SubscriptionCategory;
-use App\Domain\Subscriptions\SubscriptionUuid;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Seeder;
 use Ramsey\Uuid\Uuid;

--- a/database/seeders/SubscriptionsSeeder.php
+++ b/database/seeders/SubscriptionsSeeder.php
@@ -9,19 +9,19 @@ use App\Domain\Subscriptions\Currency;
 use App\Domain\Subscriptions\Repositories\SubscriptionRepository;
 use App\Domain\Subscriptions\Subscription;
 use App\Domain\Subscriptions\SubscriptionCategory;
-use App\Domain\Subscriptions\SubscriptionPlan;
+use App\Domain\Subscriptions\SubscriptionUuid;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Seeder;
 use Ramsey\Uuid\Uuid;
 
 final class SubscriptionsSeeder extends Seeder
 {
-    private function getSubscription(SubscriptionPlan $subscriptionPlan): Subscription
+    private function getSubscription(SubscriptionUuid $subscriptionUuid): Subscription
     {
-        $subscriptionId = Uuid::fromString($subscriptionPlan->value);
+        $subscriptionId = Uuid::fromString($subscriptionUuid->value);
 
-        return match ($subscriptionPlan) {
-            SubscriptionPlan::FREE_ENTRY_API_PLAN => new Subscription(
+        return match ($subscriptionUuid) {
+            SubscriptionUuid::FREE_ENTRY_API_PLAN => new Subscription(
                 $subscriptionId,
                 'Free Plan - Entry API',
                 'Free Plan for integrating with Entry API',
@@ -31,7 +31,7 @@ final class SubscriptionsSeeder extends Seeder
                 0,
                 0
             ),
-            SubscriptionPlan::BASIC_SEARCH_API_PLAN => new Subscription(
+            SubscriptionUuid::BASIC_SEARCH_API_PLAN => new Subscription(
                 $subscriptionId,
                 'Basic Plan - Search API - Monthly',
                 'Basic Plan for integrating with Search API, billed monthly',
@@ -41,7 +41,7 @@ final class SubscriptionsSeeder extends Seeder
                 125,
                 0
             ),
-            SubscriptionPlan::CUSTOM_SEARCH_API_PLAN => new Subscription(
+            SubscriptionUuid::CUSTOM_SEARCH_API_PLAN => new Subscription(
                 $subscriptionId,
                 'Custom Plan - Search API - Monthly',
                 'Custom Plan for integrating with Search API, billed monthly and with a onetime fee.',
@@ -51,7 +51,7 @@ final class SubscriptionsSeeder extends Seeder
                 0,
                 0
             ),
-            SubscriptionPlan::BASIC_WIDGETS_PLAN => new Subscription(
+            SubscriptionUuid::BASIC_WIDGETS_PLAN => new Subscription(
                 $subscriptionId,
                 'Basic Plan - Widgets - Monthly',
                 'Basic Plan for integrating Widgets, billed monthly.',
@@ -61,7 +61,7 @@ final class SubscriptionsSeeder extends Seeder
                 125,
                 0
             ),
-            SubscriptionPlan::PLUS_WIDGETS_PLAN => new Subscription(
+            SubscriptionUuid::PLUS_WIDGETS_PLAN => new Subscription(
                 $subscriptionId,
                 'Plus Plan - Widgets - Monthly',
                 'Plus Plan for integrating with Widgets, billed monthly and with a onetime fee.',
@@ -71,7 +71,7 @@ final class SubscriptionsSeeder extends Seeder
                 280,
                 600
             ),
-            SubscriptionPlan::CUSTOM_WIDGETS_PLAN => new Subscription(
+            SubscriptionUuid::CUSTOM_WIDGETS_PLAN => new Subscription(
                 $subscriptionId,
                 'Custom Plan - Widgets - Monthly',
                 'Custom Plan for integrating with Widgets, billed monthly and with a onetime fee.',
@@ -86,8 +86,8 @@ final class SubscriptionsSeeder extends Seeder
 
     public function run(SubscriptionRepository $subscriptionRepository): void
     {
-        foreach (SubscriptionPlan::cases() as $subscriptionPlan) {
-            $subscription = $this->getSubscription($subscriptionPlan);
+        foreach (SubscriptionUuid::cases() as $subscriptionUuid) {
+            $subscription = $this->getSubscription($subscriptionUuid);
             try {
                 $subscriptionRepository->getById($subscription->id);
             } catch (ModelNotFoundException) {

--- a/database/seeders/SubscriptionsSeeder.php
+++ b/database/seeders/SubscriptionsSeeder.php
@@ -10,6 +10,7 @@ use App\Domain\Subscriptions\Repositories\SubscriptionRepository;
 use App\Domain\Subscriptions\Subscription;
 use App\Domain\Subscriptions\SubscriptionCategory;
 use App\Domain\Subscriptions\SubscriptionPlan;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Seeder;
 use Ramsey\Uuid\Uuid;
 
@@ -87,7 +88,11 @@ final class SubscriptionsSeeder extends Seeder
     {
         foreach (SubscriptionPlan::cases() as $subscriptionPlan) {
             $subscription = $this->getSubscription($subscriptionPlan);
-            $subscriptionRepository->save($subscription);
+            try {
+                $subscriptionRepository->getByIntegrationTypeAndCategory($subscription->integrationType, $subscription->category);
+            } catch (ModelNotFoundException) {
+                $subscriptionRepository->save($subscription);
+            }
         }
     }
 }

--- a/database/seeders/SubscriptionsSeeder.php
+++ b/database/seeders/SubscriptionsSeeder.php
@@ -89,7 +89,7 @@ final class SubscriptionsSeeder extends Seeder
         foreach (SubscriptionPlan::cases() as $subscriptionPlan) {
             $subscription = $this->getSubscription($subscriptionPlan);
             try {
-                $subscriptionRepository->getByIntegrationTypeAndCategory($subscription->integrationType, $subscription->category);
+                $subscriptionRepository->getById($subscription->id);
             } catch (ModelNotFoundException) {
                 $subscriptionRepository->save($subscription);
             }


### PR DESCRIPTION
### Changed

- `SubscriptionsSeeder`: Added a check to see if a matching `Subscription` already exists, before adding them.
- Renamed `SubscriptionPlan` to `SubscriptionUuid`.
- Moved `SubscriptionUuid` to `seeders`-folder.


### Removed

- `DatabaseSeeder`: Remove `CouponSeeder` because it should only be run locally


### Fixed

- Subscriptionplans are no longer overwritten with every deploy.

---
Ticket: https://jira.publiq.be/browse/PPF-429