### PR TITLE
Avoid double slash in URI, when creating a widget.

### DIFF
--- a/app/ProjectAanvraag/ProjectAanvraagClient.php
+++ b/app/ProjectAanvraag/ProjectAanvraagClient.php
@@ -29,7 +29,7 @@ final readonly class ProjectAanvraagClient
         $baseUri = ProjectAanvraagUrl::getBaseUrlForIntegrationStatus($createWidgetRequest->status);
         $request = new Request(
             'POST',
-            $baseUri . '/project/' . $createWidgetRequest->integrationId->toString(),
+            $baseUri . 'project/' . $createWidgetRequest->integrationId->toString(),
             [],
             Json::encode([
                 'userId' => $createWidgetRequest->userId,


### PR DESCRIPTION
### Changed

- `ProjectAanvraagClient`: avoid creating a uri, with double slashes.

### Fixed

- No more `CORS`-errors when creating a WidgetProject.

---
Ticket: https://jira.publiq.be/browse/PPF-423
