### PR TITLE
PPF-435 Added scope config for Keycloak

### DIFF
--- a/app/Keycloak/ScopeConfig.php
+++ b/app/Keycloak/ScopeConfig.php
@@ -8,21 +8,21 @@ use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\IntegrationType;
 use Ramsey\Uuid\UuidInterface;
 
-final class ScopeConfig
+readonly final class ScopeConfig
 {
     public function __construct(
-        public UuidInterface $searchApi,
-        public UuidInterface $entryApi,
-        public UuidInterface $widgets,
+        public UuidInterface $searchApiScopeId,
+        public UuidInterface $entryApiScopeId,
+        public UuidInterface $ScopeId,
     ) {
     }
 
     public function getScopeIdFromIntegrationType(Integration $integration): UuidInterface
     {
         return match ($integration->type) {
-            IntegrationType::EntryApi => $this->entryApi,
-            IntegrationType::Widgets => $this->widgets,
-            IntegrationType::SearchApi => $this->searchApi
+            IntegrationType::EntryApi => $this->entryApiScopeId,
+            IntegrationType::Widgets => $this->ScopeId,
+            IntegrationType::SearchApi => $this->searchApiScopeId
         };
     }
 }

--- a/app/Keycloak/ScopeConfig.php
+++ b/app/Keycloak/ScopeConfig.php
@@ -8,7 +8,7 @@ use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\IntegrationType;
 use Ramsey\Uuid\UuidInterface;
 
-readonly final class ScopeConfig
+final readonly class ScopeConfig
 {
     public function __construct(
         public UuidInterface $searchApiScopeId,

--- a/app/Keycloak/ScopeConfig.php
+++ b/app/Keycloak/ScopeConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Keycloak;
+
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationType;
+use Ramsey\Uuid\UuidInterface;
+
+final class ScopeConfig
+{
+    public function __construct(
+        public UuidInterface $searchApi,
+        public UuidInterface $entryApi,
+        public UuidInterface $widgets,
+    ) {
+    }
+
+    public function getScopeIdFromIntegrationType(Integration $integration): UuidInterface
+    {
+        return match ($integration->type) {
+            IntegrationType::EntryApi => $this->entryApi,
+            IntegrationType::Widgets => $this->widgets,
+            IntegrationType::SearchApi => $this->searchApi
+        };
+    }
+}

--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -7,4 +7,9 @@ return [
     'base_url' => env('KEYCLOAK_BASE_URL', ''),
     'client_id' => env('KEYCLOAK_CLIENT_ID', ''),
     'client_secret' => env('KEYCLOAK_CLIENT_SECRET', ''),
+    'scope' => [
+        'search_api_id' => env('KEYCLOAK_SCOPE_SEARCH_API_ID', ''),
+        'entry_api_id' => env('KEYCLOAK_SCOPE_ENTRY_API_ID', ''),
+        'widgets_id' => env('KEYCLOAK_SCOPE_WIDGETS_ID', ''),
+    ],
 ];

--- a/tests/IntegrationHelper.php
+++ b/tests/IntegrationHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationPartnerStatus;
+use App\Domain\Integrations\IntegrationStatus;
+use App\Domain\Integrations\IntegrationType;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+trait IntegrationHelper
+{
+    public function createIntegration(UuidInterface $integrationId, array $options = []): Integration
+    {
+        return new Integration(
+            $integrationId,
+            $options['type'] ?? IntegrationType::SearchApi,
+            $options['name'] ?? 'Mock Integration',
+            $options['description'] ?? 'Mock description',
+            Uuid::uuid4(),
+            $options['status'] ?? IntegrationStatus::Draft,
+            $options['partnerStatus'] ?? IntegrationPartnerStatus::THIRD_PARTY,
+        );
+    }
+}

--- a/tests/IntegrationHelper.php
+++ b/tests/IntegrationHelper.php
@@ -13,7 +13,7 @@ use Ramsey\Uuid\UuidInterface;
 
 trait IntegrationHelper
 {
-    public function createIntegration(UuidInterface $integrationId, array $options = []): Integration
+    public function givenThereIsAnIntegration(UuidInterface $integrationId, array $options = []): Integration
     {
         return new Integration(
             $integrationId,

--- a/tests/Keycloak/ScopeConfigTest.php
+++ b/tests/Keycloak/ScopeConfigTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keycloak;
+
+use App\Domain\Integrations\IntegrationType;
+use App\Keycloak\ScopeConfig;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Tests\IntegrationHelper;
+
+final class ScopeConfigTest extends TestCase
+{
+    use IntegrationHelper;
+
+    private const SEARCH_API_ID = '41255857-b8ad-44ce-9a17-db72540461b7';
+    private const ENTRY_API_ID = '824c09c0-2f3a-4fa0-bde2-8bf25c9a5b74';
+    private const WIDGETS_ID = 'deb654ab-1324-48ca-9931-1485a456c916';
+
+    private ScopeConfig $scopeConfig;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = new ScopeConfig(
+            Uuid::fromString(self::SEARCH_API_ID),
+            Uuid::fromString(self::ENTRY_API_ID),
+            Uuid::fromString(self::WIDGETS_ID)
+        );
+    }
+
+    /**
+     * @dataProvider integrationDataProvider
+     */
+    public function test_get_scope_id_from_integration(IntegrationType $type, string $expectedScopeId): void
+    {
+        $actualScopeId = $this->scopeConfig->getScopeIdFromIntegrationType(
+            $this->createIntegration(Uuid::uuid4(), ['type' => $type])
+        );
+
+        $this->assertEquals($expectedScopeId, $actualScopeId->toString());
+    }
+
+    public static function integrationDataProvider(): array
+    {
+        return [
+            [IntegrationType::SearchApi, self::SEARCH_API_ID],
+            [IntegrationType::EntryApi, self::ENTRY_API_ID],
+            [IntegrationType::Widgets, self::WIDGETS_ID],
+        ];
+    }
+}

--- a/tests/Keycloak/ScopeConfigTest.php
+++ b/tests/Keycloak/ScopeConfigTest.php
@@ -35,7 +35,7 @@ final class ScopeConfigTest extends TestCase
     public function test_get_scope_id_from_integration(IntegrationType $type, string $expectedScopeId): void
     {
         $actualScopeId = $this->scopeConfig->getScopeIdFromIntegrationType(
-            $this->createIntegration(Uuid::uuid4(), ['type' => $type])
+            $this->givenThereIsAnIntegration(Uuid::uuid4(), ['type' => $type])
         );
 
         $this->assertEquals($expectedScopeId, $actualScopeId->toString());


### PR DESCRIPTION
### Added
Scope in Keycloak is wat determines what a client can do, in Publiq Platform this is dependant on the Integration type.
We need to know the scope id in Keycloak to add this to our client.

In a later PR an API call we be that adds this scope to a client.

Contains an extra helper for the unit tests - might seem overkill now but I will need to create a lot of integrations for later Unit tests. ;-)

---
Ticket: https://jira.uitdatabank.be/browse/PPF-435