### PR TITLE
PPF-435 Complete flow creating client keycloak

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -147,6 +147,6 @@ KEYCLOAK_CLIENT_ID='not_real_client'
 KEYCLOAK_CLIENT_SECRET='not_the_real_secret'
 
 # Incorrect values, but need to contain a valid UUID formatted string
-KEYCLOAK_SCOPE_SEARCH_API_ID='1e4ee5485-08ce-48fb-abc8-0775293242c0' #publiq-api-sapi-scope
-KEYCLOAK_SCOPE_ENTRY_API_ID='e4ee5485-08ce-48fb-abc8-0775293242c0' #publiq-api-entry-scope
-KEYCLOAK_SCOPE_WIDGETS_ID='e4ee5485-08ce-48fb-abc8-0775293242c0'#publiq-widget-scope
+KEYCLOAK_SCOPE_SEARCH_API_ID='bcfb28cc-454f-488a-b080-6a29d9c0158e' #publiq-api-sapi-scope
+KEYCLOAK_SCOPE_ENTRY_API_ID='bcfb28cc-454f-488a-b080-6a29d9c0158e' #publiq-api-entry-scope
+KEYCLOAK_SCOPE_WIDGETS_ID='bcfb28cc-454f-488a-b080-6a29d9c0158e'#publiq-widget-scope

--- a/.env.ci
+++ b/.env.ci
@@ -140,3 +140,13 @@ E2E_TEST_PASSWORD=
 
 E2E_TEST_ADMIN_EMAIL=dev+e2etest-admin@publiq.be
 E2E_TEST_ADMIN_PASSWORD=
+
+KEYCLOAK_ENABLE=true
+KEYCLOAK_BASE_URL='https://account.kcpoc.lodgon.com/'
+KEYCLOAK_CLIENT_ID='not_real_client'
+KEYCLOAK_CLIENT_SECRET='not_the_real_secret'
+
+# Incorrect values, but need to contain a valid UUID formatted string
+KEYCLOAK_SCOPE_SEARCH_API_ID='1e4ee5485-08ce-48fb-abc8-0775293242c0' #publiq-api-sapi-scope
+KEYCLOAK_SCOPE_ENTRY_API_ID='e4ee5485-08ce-48fb-abc8-0775293242c0' #publiq-api-entry-scope
+KEYCLOAK_SCOPE_WIDGETS_ID='e4ee5485-08ce-48fb-abc8-0775293242c0'#publiq-widget-scope

--- a/app/Console/Commands/KeycloakCreateClient.php
+++ b/app/Console/Commands/KeycloakCreateClient.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\Keycloak\Config;
+use App\Keycloak\ScopeConfig;
+use App\Keycloak\Service\ApiClient;
+use App\Keycloak\Service\CreateClientFlow;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+
+final class KeycloakCreateClient extends Command
+{
+    protected $signature = 'keycloak:create-client {integrationId : The integration ID}';
+
+    protected $description = 'Create a Keycloak client';
+
+    public function __construct(
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly ApiClient $apiClient,
+        private readonly Config $config,
+        private readonly ScopeConfig $scopeConfig,
+        private readonly LoggerInterface $logger
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $integrationId = $this->argument('integrationId');
+        try {
+            $integration = $this->integrationRepository->getById(Uuid::fromString($integrationId));
+        } catch (ModelNotFoundException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $flow = new CreateClientFlow(
+            $this->apiClient,
+            $this->config,
+            $this->scopeConfig,
+            $this->logger
+        );
+
+        $clients = $flow->createClientsForIntegration($integration);
+
+        foreach ($clients as $client) {
+            $this->info(sprintf("Created Keycloak client for realm '%s' with client ID: %s", $client->realm->internalName, $client->clientId));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/KeycloakCreateClient.php
+++ b/app/Console/Commands/KeycloakCreateClient.php
@@ -48,7 +48,7 @@ final class KeycloakCreateClient extends Command
             $this->logger
         );
 
-        $clients = $flow->handle($integration);
+        $clients = $createClientHandler->handle($integration);
 
         foreach ($clients as $client) {
             $this->info(sprintf("Created Keycloak client for realm '%s' with client ID: %s", $client->realm->internalName, $client->clientId));

--- a/app/Console/Commands/KeycloakCreateClient.php
+++ b/app/Console/Commands/KeycloakCreateClient.php
@@ -41,7 +41,7 @@ final class KeycloakCreateClient extends Command
             return self::FAILURE;
         }
 
-        $flow = new CreateClientHandler(
+        $createClientHandler = new CreateClientHandler(
             $this->apiClient,
             $this->config,
             $this->scopeConfig,

--- a/app/Console/Commands/KeycloakCreateClient.php
+++ b/app/Console/Commands/KeycloakCreateClient.php
@@ -8,7 +8,7 @@ use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Keycloak\Config;
 use App\Keycloak\ScopeConfig;
 use App\Keycloak\Service\ApiClient;
-use App\Keycloak\Service\CreateClientFlow;
+use App\Keycloak\Service\CreateClientHandler;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Psr\Log\LoggerInterface;
@@ -41,14 +41,14 @@ final class KeycloakCreateClient extends Command
             return self::FAILURE;
         }
 
-        $flow = new CreateClientFlow(
+        $flow = new CreateClientHandler(
             $this->apiClient,
             $this->config,
             $this->scopeConfig,
             $this->logger
         );
 
-        $clients = $flow->createClientsForIntegration($integration);
+        $clients = $flow->handle($integration);
 
         foreach ($clients as $client) {
             $this->info(sprintf("Created Keycloak client for realm '%s' with client ID: %s", $client->realm->internalName, $client->clientId));

--- a/app/Keycloak/ClientCollection.php
+++ b/app/Keycloak/ClientCollection.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Keycloak;
+
+use Illuminate\Support\Collection;
+
+/**
+ * @extends Collection<int, Client>
+ */
+final class ClientCollection extends Collection
+{
+}

--- a/app/Keycloak/KeycloakServiceProvider.php
+++ b/app/Keycloak/KeycloakServiceProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Keycloak;
+
+use App\Keycloak\Client\KeycloakClientWithBearer;
+use App\Keycloak\Client\KeycloakClientWithoutBearer;
+use App\Keycloak\Service\ApiClient;
+use App\Keycloak\TokenStrategy\ClientCredentials;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\ServiceProvider;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+
+final class KeycloakServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(ApiClient::class, function () {
+            $client = new Client([RequestOptions::HTTP_ERRORS => false]);
+
+            $keycloakClientWithoutBearer = new KeycloakClientWithoutBearer(
+                $client,
+                $this->app->get(Config::class)
+            );
+
+            $keycloakClient = new KeycloakClientWithBearer(
+                $client,
+                $this->app->get(Config::class),
+                new ClientCredentials(
+                    $keycloakClientWithoutBearer,
+                    $this->app->get(Config::class),
+                    $this->app->get(LoggerInterface::class)
+                )
+            );
+
+            return new ApiClient(
+                $keycloakClient,
+                $this->app->get(LoggerInterface::class),
+            );
+        });
+
+        $this->app->singleton(Config::class, function () {
+            return new Config(
+                config('keycloak.enabled'),
+                config('keycloak.base_url'),
+                config('keycloak.client_id'),
+                config('keycloak.client_secret'),
+                RealmCollection::getDefaultRealms(),
+            );
+        });
+
+        $this->app->singleton(ScopeConfig::class, function () {
+            return new ScopeConfig(
+                Uuid::fromString(config('keycloak.scope.search_api_id')),
+                Uuid::fromString(config('keycloak.scope.entry_api_id')),
+                Uuid::fromString(config('keycloak.scope.widgets_id')),
+            );
+        });
+    }
+}

--- a/app/Keycloak/Service/CreateClientFlow.php
+++ b/app/Keycloak/Service/CreateClientFlow.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Keycloak\Service;
+
+use App\Domain\Integrations\Integration;
+use App\Keycloak\ClientCollection;
+use App\Keycloak\Config;
+use App\Keycloak\Exception\KeyCloakApiFailed;
+use App\Keycloak\ScopeConfig;
+use Psr\Log\LoggerInterface;
+
+final readonly class CreateClientFlow
+{
+    public function __construct(
+        private ApiClient $client,
+        private Config $config,
+        private ScopeConfig $scopeConfig,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    public function createClientsForIntegration(Integration $integration): ClientCollection
+    {
+        $scopeId = $this->scopeConfig->getScopeIdFromIntegrationType($integration);
+
+        $clientCollection = new ClientCollection();
+
+        foreach ($this->config->realms as $realm) {
+            try {
+                $clientId = $this->client->createClient($realm, $integration);
+                $this->client->addScopeToClient($realm, $clientId, $scopeId);
+
+                $client = $this->client->fetchClient($realm, $integration);
+                $clientCollection->add($client);
+            } catch (KeyCloakApiFailed $e) {
+                $this->logger->error($e->getMessage());
+            }
+        }
+
+        return $clientCollection;
+    }
+}

--- a/app/Keycloak/Service/CreateClientHandler.php
+++ b/app/Keycloak/Service/CreateClientHandler.php
@@ -11,7 +11,7 @@ use App\Keycloak\Exception\KeyCloakApiFailed;
 use App\Keycloak\ScopeConfig;
 use Psr\Log\LoggerInterface;
 
-final readonly class CreateClientFlow
+final readonly class CreateClientHandler
 {
     public function __construct(
         private ApiClient $client,
@@ -21,7 +21,7 @@ final readonly class CreateClientFlow
     ) {
     }
 
-    public function createClientsForIntegration(Integration $integration): ClientCollection
+    public function handle(Integration $integration): ClientCollection
     {
         $scopeId = $this->scopeConfig->getScopeIdFromIntegrationType($integration);
 

--- a/config/app.php
+++ b/config/app.php
@@ -202,6 +202,7 @@ return [
         App\Providers\RouteServiceProvider::class,
         App\UiTiDv1\UiTiDv1ServiceProvider::class,
         App\ProjectAanvraag\ProjectAanvraagServiceProvider::class,
+        App\Keycloak\KeycloakServiceProvider::class,
     ],
 
     /*


### PR DESCRIPTION
### Added
This pr adds the bootstrapping / service provider of the ApiClient of Keycloak, for later use.

It also contains a class CreateClientFlow, which runs the entire flow of
- creating a client
- add the correct scope
- retrieving the client information (secret) for later storage

It also has a CLI command to create a client from an integration.
While this was not requested, it is useful as a proof of concept / handy during testing.

# Related
https://github.com/cultuurnet/appconfig/pull/616

---
Ticket: https://jira.uitdatabank.be/browse/PPF-435
