### PR TITLE
PPF-488 Always send the groups when updating uitidv1

### DIFF
--- a/app/UiTiDv1/Jobs/ActivateConsumerHandler.php
+++ b/app/UiTiDv1/Jobs/ActivateConsumerHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\UiTiDv1\Jobs;
 
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\UiTiDv1\Events\ConsumerActivated;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
 use App\UiTiDv1\UiTiDv1ClusterSDK;
@@ -21,6 +22,7 @@ final class ActivateConsumerHandler implements ShouldQueue
     public function __construct(
         private readonly UiTiDv1ClusterSDK $clusterSDK,
         private readonly UiTiDv1ConsumerRepository $consumerRepository,
+        private readonly IntegrationRepository $integrationRepository,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -28,7 +30,9 @@ final class ActivateConsumerHandler implements ShouldQueue
     public function handle(ActivateConsumer $event): void
     {
         try {
-            $this->clusterSDK->activateConsumers($this->consumerRepository->getById($event->id));
+            $uiTiDv1Consumer = $this->consumerRepository->getById($event->id);
+            $integration = $this->integrationRepository->getById($uiTiDv1Consumer->integrationId);
+            $this->clusterSDK->activateConsumers($integration, $uiTiDv1Consumer);
         } catch (ModelNotFoundException|UiTiDv1SDKException $e) {
             $this->logger->error(
                 'Failed to activate UiTiD v1 client: ' . $e->getMessage(),

--- a/app/UiTiDv1/Listeners/BlockConsumers.php
+++ b/app/UiTiDv1/Listeners/BlockConsumers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\UiTiDv1\Listeners;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
 use App\UiTiDv1\UiTiDv1ClusterSDK;
 use Illuminate\Bus\Queueable;
@@ -19,6 +20,7 @@ final class BlockConsumers implements ShouldQueue
     public function __construct(
         private readonly UiTiDv1ClusterSDK $clusterSDK,
         private readonly UiTiDv1ConsumerRepository $consumerRepository,
+        private readonly IntegrationRepository $integrationRepository,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -27,7 +29,8 @@ final class BlockConsumers implements ShouldQueue
     {
         $consumers = $this->consumerRepository->getByIntegrationId($integrationBlocked->id);
 
-        $this->clusterSDK->blockConsumers(...$consumers);
+        $integration = $this->integrationRepository->getById($integrationBlocked->id);
+        $this->clusterSDK->blockConsumers($integration, ... $consumers);
 
         $this->logger->info(
             'UiTiD v1 consumer(s) blocked',

--- a/app/UiTiDv1/UiTiDv1ClusterSDK.php
+++ b/app/UiTiDv1/UiTiDv1ClusterSDK.php
@@ -57,17 +57,17 @@ final class UiTiDv1ClusterSDK
         return $this->uitidv1EnvironmentSDKs[$environment->value]->createConsumerForIntegration($integration);
     }
 
-    public function blockConsumers(UiTiDv1Consumer ...$uiTiDv1Consumers): void
+    public function blockConsumers(Integration $integration, UiTiDv1Consumer ...$uiTiDv1Consumers): void
     {
         foreach ($uiTiDv1Consumers as $uiTiDv1Consumer) {
-            $this->uitidv1EnvironmentSDKs[$uiTiDv1Consumer->environment->value]->blockConsumer($uiTiDv1Consumer);
+            $this->uitidv1EnvironmentSDKs[$uiTiDv1Consumer->environment->value]->blockConsumer($integration, $uiTiDv1Consumer);
         }
     }
 
-    public function activateConsumers(UiTiDv1Consumer ...$uiTiDv1Consumers): void
+    public function activateConsumers(Integration $integration, UiTiDv1Consumer ...$uiTiDv1Consumers): void
     {
         foreach ($uiTiDv1Consumers as $uiTiDv1Consumer) {
-            $this->uitidv1EnvironmentSDKs[$uiTiDv1Consumer->environment->value]->activateConsumer($uiTiDv1Consumer);
+            $this->uitidv1EnvironmentSDKs[$uiTiDv1Consumer->environment->value]->activateConsumer($integration, $uiTiDv1Consumer);
         }
     }
 

--- a/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
+++ b/app/UiTiDv1/UiTiDv1EnvironmentSDK.php
@@ -56,22 +56,25 @@ final class UiTiDv1EnvironmentSDK
     {
         $formData = [
             'name' => $this->consumerName($integration),
+            'group' => $this->permissionGroupsPerIntegrationType[$integration->type->value] ?? [],
         ];
 
         $this->sendPostRequest('serviceconsumer/' . $consumer->consumerKey, $formData);
     }
 
-    public function blockConsumer(UiTiDv1Consumer $consumer): void
+    public function blockConsumer(Integration $integration, UiTiDv1Consumer $consumer): void
     {
         $this->sendPostRequest('serviceconsumer/' . $consumer->consumerKey, [
             'status' => UiTiDv1ConsumerStatus::Blocked->value,
+            'group' => $this->permissionGroupsPerIntegrationType[$integration->type->value] ?? [],
         ]);
     }
 
-    public function activateConsumer(UiTiDv1Consumer $consumer): void
+    public function activateConsumer(Integration $integration, UiTiDv1Consumer $consumer): void
     {
         $this->sendPostRequest('serviceconsumer/' . $consumer->consumerKey, [
             'status' => UiTiDv1ConsumerStatus::Active->value,
+            'group' => $this->permissionGroupsPerIntegrationType[$integration->type->value] ?? [],
         ]);
     }
 

--- a/tests/CreateIntegration.php
+++ b/tests/CreateIntegration.php
@@ -11,7 +11,7 @@ use App\Domain\Integrations\IntegrationType;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
-trait IntegrationHelper
+trait CreateIntegration
 {
     public function givenThereIsAnIntegration(UuidInterface $integrationId, array $options = []): Integration
     {

--- a/tests/IntegrationHelper.php
+++ b/tests/IntegrationHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationPartnerStatus;
+use App\Domain\Integrations\IntegrationStatus;
+use App\Domain\Integrations\IntegrationType;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+trait IntegrationHelper
+{
+    public function givenThereIsAnIntegration(UuidInterface $integrationId, array $options = []): Integration
+    {
+        return new Integration(
+            $integrationId,
+            $options['type'] ?? IntegrationType::SearchApi,
+            $options['name'] ?? 'Mock Integration',
+            $options['description'] ?? 'Mock description',
+            Uuid::uuid4(),
+            $options['status'] ?? IntegrationStatus::Draft,
+            $options['partnerStatus'] ?? IntegrationPartnerStatus::THIRD_PARTY,
+        );
+    }
+}

--- a/tests/UiTiDv1/Jobs/ActivateConsumerHandlerTest.php
+++ b/tests/UiTiDv1/Jobs/ActivateConsumerHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\UiTiDv1\Jobs;
 
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\UiTiDv1\Events\ConsumerActivated;
 use App\UiTiDv1\Jobs\ActivateConsumer;
 use App\UiTiDv1\Jobs\ActivateConsumerHandler;
@@ -16,6 +17,7 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
+use Tests\IntegrationHelper;
 use Tests\TestCase;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 use Tests\UiTiDv1\CreatesMockUiTiDv1Consumer;
@@ -24,11 +26,11 @@ final class ActivateConsumerHandlerTest extends TestCase
 {
     use CreatesMockUiTiDv1ClusterSDK;
     use CreatesMockUiTiDv1Consumer;
+    use IntegrationHelper;
 
     private ClientInterface&MockObject $httpClient;
-
     private UiTiDv1ConsumerRepository&MockObject $clientRepository;
-
+    private IntegrationRepository&MockObject $integrationRepository;
     private ActivateConsumerHandler $activateClient;
 
     protected function setUp(): void
@@ -38,10 +40,12 @@ final class ActivateConsumerHandlerTest extends TestCase
         $this->httpClient = $this->createMock(ClientInterface::class);
 
         $this->clientRepository = $this->createMock(UiTiDv1ConsumerRepository::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
 
         $this->activateClient = new ActivateConsumerHandler(
             $this->createMockUiTiDv1ClusterSDK($this->httpClient),
             $this->clientRepository,
+            $this->integrationRepository,
             new NullLogger()
         );
     }
@@ -49,10 +53,16 @@ final class ActivateConsumerHandlerTest extends TestCase
     public function test_does_it_sent_an_activate_request(): void
     {
         $id = Uuid::uuid4();
+        $uiTiDv1Consumer = $this->createConsumer($id);
         $this->clientRepository->expects($this->once())
             ->method('getById')
             ->with($id)
-            ->willReturn($this->createConsumer($id));
+            ->willReturn($uiTiDv1Consumer);
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with($uiTiDv1Consumer->integrationId)
+            ->willReturn($this->givenThereIsAnIntegration($id));
 
         $this->httpClient->expects($this->once())
             ->method('request')
@@ -62,7 +72,7 @@ final class ActivateConsumerHandlerTest extends TestCase
                         [
                             'POST',
                             'serviceconsumer/consumer-key-1',
-                            'status=ACTIVE',
+                            'status=ACTIVE&group=3',
                         ]
                         => new Response(200, [], ''),
                         default => throw new LogicException('Invalid arguments received'),
@@ -73,7 +83,6 @@ final class ActivateConsumerHandlerTest extends TestCase
         $this->activateClient->handle(new ActivateConsumer($id));
 
         Event::assertDispatched(ConsumerActivated::class);
-
     }
 
     public function test_it_does_not_try_to_block_an_invalid_client(): void
@@ -96,10 +105,16 @@ final class ActivateConsumerHandlerTest extends TestCase
     public function test_it_stops_on_invalid_request(): void
     {
         $id = Uuid::uuid4();
+        $uiTiDv1Consumer = $this->createConsumer($id);
         $this->clientRepository->expects($this->once())
             ->method('getById')
             ->with($id)
-            ->willReturn($this->createConsumer($id));
+            ->willReturn($uiTiDv1Consumer);
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with($uiTiDv1Consumer->integrationId)
+            ->willReturn($this->givenThereIsAnIntegration($id));
 
         $this->httpClient->expects($this->once())
             ->method('request')

--- a/tests/UiTiDv1/Jobs/ActivateConsumerHandlerTest.php
+++ b/tests/UiTiDv1/Jobs/ActivateConsumerHandlerTest.php
@@ -17,7 +17,7 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
-use Tests\IntegrationHelper;
+use Tests\CreateIntegration;
 use Tests\TestCase;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 use Tests\UiTiDv1\CreatesMockUiTiDv1Consumer;
@@ -26,7 +26,7 @@ final class ActivateConsumerHandlerTest extends TestCase
 {
     use CreatesMockUiTiDv1ClusterSDK;
     use CreatesMockUiTiDv1Consumer;
-    use IntegrationHelper;
+    use CreateIntegration;
 
     private ClientInterface&MockObject $httpClient;
     private UiTiDv1ConsumerRepository&MockObject $clientRepository;

--- a/tests/UiTiDv1/Jobs/BlockConsumerHandlerTest.php
+++ b/tests/UiTiDv1/Jobs/BlockConsumerHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\UiTiDv1\Jobs;
 
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\UiTiDv1\Events\ConsumerBlocked;
 use App\UiTiDv1\Jobs\BlockConsumer;
 use App\UiTiDv1\Jobs\BlockConsumerHandler;
@@ -16,6 +17,7 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
+use Tests\IntegrationHelper;
 use Tests\TestCase;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 use Tests\UiTiDv1\CreatesMockUiTiDv1Consumer;
@@ -24,11 +26,11 @@ final class BlockConsumerHandlerTest extends TestCase
 {
     use CreatesMockUiTiDv1ClusterSDK;
     use CreatesMockUiTiDv1Consumer;
+    use IntegrationHelper;
 
     private ClientInterface&MockObject $httpClient;
-
     private UiTiDv1ConsumerRepository&MockObject $clientRepository;
-
+    private IntegrationRepository&MockObject $integrationRepository;
     private BlockConsumerHandler $blockClient;
 
 
@@ -37,12 +39,13 @@ final class BlockConsumerHandlerTest extends TestCase
         parent::setUp();
 
         $this->httpClient = $this->createMock(ClientInterface::class);
-
         $this->clientRepository = $this->createMock(UiTiDv1ConsumerRepository::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
 
         $this->blockClient = new BlockConsumerHandler(
             $this->createMockUiTiDv1ClusterSDK($this->httpClient),
             $this->clientRepository,
+            $this->integrationRepository,
             new NullLogger()
         );
     }
@@ -55,6 +58,10 @@ final class BlockConsumerHandlerTest extends TestCase
             ->with($id)
             ->willReturn($this->createConsumer($id));
 
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->willReturn($this->givenThereIsAnIntegration($id));
+
         $this->httpClient->expects($this->once())
             ->method('request')
             ->willReturnCallback(
@@ -63,7 +70,7 @@ final class BlockConsumerHandlerTest extends TestCase
                         [
                             'POST',
                             'serviceconsumer/consumer-key-1',
-                            'status=BLOCKED',
+                            'status=BLOCKED&group=3',
                         ]
                         => new Response(200, [], ''),
                         default => throw new LogicException('Invalid arguments received'),
@@ -96,10 +103,15 @@ final class BlockConsumerHandlerTest extends TestCase
     public function test_it_stops_on_invalid_request(): void
     {
         $id = Uuid::uuid4();
+        $uiTiDv1Consumer = $this->createConsumer($id);
         $this->clientRepository->expects($this->once())
             ->method('getById')
             ->with($id)
-            ->willReturn($this->createConsumer($id));
+            ->willReturn($uiTiDv1Consumer);
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->willReturn($this->givenThereIsAnIntegration($id));
 
         $this->httpClient->expects($this->once())
             ->method('request')

--- a/tests/UiTiDv1/Jobs/BlockConsumerHandlerTest.php
+++ b/tests/UiTiDv1/Jobs/BlockConsumerHandlerTest.php
@@ -17,7 +17,7 @@ use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
-use Tests\IntegrationHelper;
+use Tests\CreateIntegration;
 use Tests\TestCase;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 use Tests\UiTiDv1\CreatesMockUiTiDv1Consumer;
@@ -26,7 +26,7 @@ final class BlockConsumerHandlerTest extends TestCase
 {
     use CreatesMockUiTiDv1ClusterSDK;
     use CreatesMockUiTiDv1Consumer;
-    use IntegrationHelper;
+    use CreateIntegration;
 
     private ClientInterface&MockObject $httpClient;
     private UiTiDv1ConsumerRepository&MockObject $clientRepository;

--- a/tests/UiTiDv1/Listeners/BlockConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/BlockConsumersTest.php
@@ -16,13 +16,13 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
-use Tests\IntegrationHelper;
+use Tests\CreateIntegration;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 
 final class BlockConsumersTest extends TestCase
 {
     use CreatesMockUiTiDv1ClusterSDK;
-    use IntegrationHelper;
+    use CreateIntegration;
 
     private ClientInterface&MockObject $httpClient;
     private UiTiDv1ConsumerRepository&MockObject $consumerRepository;

--- a/tests/UiTiDv1/Listeners/BlockConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/BlockConsumersTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\UiTiDv1\Listeners;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\UiTiDv1\Listeners\BlockConsumers;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
 use App\UiTiDv1\UiTiDv1Consumer;
@@ -15,26 +16,29 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
+use Tests\IntegrationHelper;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 
 final class BlockConsumersTest extends TestCase
 {
     use CreatesMockUiTiDv1ClusterSDK;
+    use IntegrationHelper;
 
     private ClientInterface&MockObject $httpClient;
-
     private UiTiDv1ConsumerRepository&MockObject $consumerRepository;
-
+    private IntegrationRepository&MockObject $integrationRepository;
     private BlockConsumers $blockConsumers;
 
     protected function setUp(): void
     {
         $this->httpClient = $this->createMock(ClientInterface::class);
         $this->consumerRepository = $this->createMock(UiTiDv1ConsumerRepository::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
 
         $this->blockConsumers = new BlockConsumers(
             $this->createMockUiTiDv1ClusterSDK($this->httpClient),
             $this->consumerRepository,
+            $this->integrationRepository,
             $this->createMock(LoggerInterface::class)
         );
     }
@@ -78,6 +82,10 @@ final class BlockConsumersTest extends TestCase
             ->with($integrationId)
             ->willReturn($consumers);
 
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->willReturn($this->givenThereIsAnIntegration($integrationId));
+
         $this->httpClient->expects($this->exactly(3))
             ->method('request')
             ->willReturnCallback(
@@ -89,7 +97,7 @@ final class BlockConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'status=BLOCKED',
+                            'body' => 'status=BLOCKED&group=3',
                         ],
                     ],
                     [
@@ -98,7 +106,7 @@ final class BlockConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'status=BLOCKED',
+                            'body' => 'status=BLOCKED&group=9',
                         ],
                     ],
                     [
@@ -107,7 +115,7 @@ final class BlockConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'status=BLOCKED',
+                            'body' => 'status=BLOCKED&group=15',
                         ],
                     ] => new Response(200, [], ''),
                     default => throw new \LogicException('Invalid arguments received'),

--- a/tests/UiTiDv1/Listeners/UpdateConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/UpdateConsumersTest.php
@@ -113,7 +113,7 @@ final class UpdateConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29',
+                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29&group=1&group=2',
                         ],
                     ],
                     [
@@ -122,7 +122,7 @@ final class UpdateConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29',
+                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29&group=7&group=8',
                         ],
                     ],
                     [
@@ -131,7 +131,7 @@ final class UpdateConsumersTest extends TestCase
                         [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29',
+                            'body' => 'name=Mock%20Integration%20%28via%20publiq%20platform%29&group=13&group=14',
                         ],
                     ] => new Response(200, [], ''),
                     default => throw new \LogicException('Invalid arguments received'),


### PR DESCRIPTION
### Fixed
Activating an integration removes the consumer groups in UiTID.
To fix this, I now always sent the groups when updating an UiTiDv1 consumer.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-488