### PR TITLE
PPF-485 unblock integration locally

### DIFF
--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -81,6 +81,11 @@ final class IntegrationModel extends UuidModel
         return $this->status !== IntegrationStatus::Blocked->value;
     }
 
+    public function canBeUnblocked(): bool
+    {
+        return $this->status === IntegrationStatus::Blocked->value;
+    }
+
     public function isWidgets(): bool
     {
         return $this->type === IntegrationType::Widgets->value;
@@ -144,6 +149,12 @@ final class IntegrationModel extends UuidModel
             'status' => IntegrationStatus::Blocked,
         ]);
         IntegrationBlocked::dispatch(Uuid::fromString($this->id));
+    }
+
+    public function unblock(): void
+    {
+        // TODO: Get Previous status
+        // TODO: Update in all various linked platforms
     }
 
     /**

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -153,8 +153,22 @@ final class IntegrationModel extends UuidModel
 
     public function unblock(): void
     {
-        // TODO: Get Previous status
-        // TODO: Update in all various linked platforms
+        $activities = $this->activityLog()->latest()->get();
+
+        if ($activities->isEmpty()) {
+            return;
+        }
+        $activity = $activities->first(function ($activity) {
+            return $activity->properties !== null && array_key_exists('status', $activity->properties->get('old', []));
+        });
+
+        if ($activity !== null && $activity->properties !== null) {
+            $this->update([
+                'status' => $activity->properties->get('old')['status'],
+            ]);
+        }
+
+        // TODO: also unblock in all various linked platforms
     }
 
     /**

--- a/app/Nova/Actions/UnblockIntegration.php
+++ b/app/Nova/Actions/UnblockIntegration.php
@@ -11,8 +11,6 @@ use Laravel\Nova\Fields\ActionFields;
 
 final class UnblockIntegration extends Action
 {
-    public $name = 'Unblock Integration';
-
     public function handle(ActionFields $fields, Collection $integrations): void
     {
         /** @var IntegrationModel $integration */

--- a/app/Nova/Actions/UnblockIntegration.php
+++ b/app/Nova/Actions/UnblockIntegration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions;
+
+use App\Domain\Integrations\Models\IntegrationModel;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+
+final class UnblockIntegration extends Action
+{
+    public $name = 'Unblock Integration';
+
+    public function handle(ActionFields $fields, Collection $integrations): void
+    {
+        /** @var IntegrationModel $integration */
+        foreach ($integrations as $integration) {
+            $integration->unblock();
+        }
+    }
+}

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -16,6 +16,7 @@ use App\Nova\Actions\Auth0\CreateMissingAuth0Clients;
 use App\Nova\Actions\BlockIntegration;
 use App\Nova\Actions\OpenWidgetManager;
 use App\Nova\Actions\UiTiDv1\CreateMissingUiTiDv1Consumers;
+use App\Nova\Actions\UnblockIntegration;
 use App\Nova\Resource;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -205,6 +206,14 @@ final class Integration extends Resource
                 ->cancelButtonText('Cancel')
                 ->canSee(fn (Request $request) => $request instanceof ActionRequest || $this->canBeBlocked())
                 ->canRun(fn (Request $request, IntegrationModel $model) => $model->canBeBlocked()),
+
+            (new UnblockIntegration())
+            ->exceptOnIndex()
+                ->confirmText('Are you sure you want to unblock this integration?')
+                ->confirmButtonText('Unblock')
+                ->cancelButtonText('Cancel')
+                ->canSee(fn (Request $request) => $request instanceof ActionRequest || $this->canBeUnblocked())
+                ->canRun(fn (Request $request, IntegrationModel $model) => $model->canBeUnblocked()),
 
             (new CreateMissingAuth0Clients())
                 ->withName('Create missing Auth0 Clients')


### PR DESCRIPTION
### Added

- `Nova/Actions/UnblockIntegration`: `Action` to take care of the Unblocking.

### Changed

- `IntegrationModel`: added `unblock()` & `canBeUnblocked()`
- `app/Nova/Resources/Integration`: Add `Unblock Integration` button

### Fixed

- An admin can unblock an `Integration` in the `Nova`-panel, it wil be put back to the `status` the `Integration` had before blocking it.

### TODO

- Also unblock the `Integration` in related external services(will be done in following PR's)

---
Ticket: https://jira.publiq.be/browse/PPF-485
