### PR TITLE
PPF-485: unblock integration on projectaanvraag

### DIFF
--- a/app/Domain/Integrations/Events/IntegrationUnblocked.php
+++ b/app/Domain/Integrations/Events/IntegrationUnblocked.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Ramsey\Uuid\UuidInterface;
+
+final class IntegrationUnblocked
+{
+    use Dispatchable;
+
+    public function __construct(public readonly UuidInterface $id)
+    {
+    }
+}

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -13,6 +13,7 @@ use App\Domain\Integrations\Events\IntegrationActivationRequested;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Events\IntegrationDeleted;
+use App\Domain\Integrations\Events\IntegrationUnblocked;
 use App\Domain\Integrations\Events\IntegrationUpdated;
 use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\IntegrationPartnerStatus;
@@ -167,6 +168,8 @@ final class IntegrationModel extends UuidModel
                 'status' => $activity->properties->get('old')['status'],
             ]);
         }
+
+        IntegrationUnblocked::dispatch(Uuid::fromString($this->id));
 
         // TODO: also unblock in all various linked platforms
     }

--- a/app/ProjectAanvraag/Listeners/SyncWidget.php
+++ b/app/ProjectAanvraag/Listeners/SyncWidget.php
@@ -182,6 +182,7 @@ final class SyncWidget implements ShouldQueue
         ConsumerCreated|
         IntegrationActivated|
         IntegrationBlocked|
+        IntegrationUnblocked|
         IntegrationDeleted|
         IntegrationUpdated $event,
         Throwable $throwable

--- a/app/ProjectAanvraag/Listeners/SyncWidget.php
+++ b/app/ProjectAanvraag/Listeners/SyncWidget.php
@@ -12,6 +12,7 @@ use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Events\IntegrationDeleted;
+use App\Domain\Integrations\Events\IntegrationUnblocked;
 use App\Domain\Integrations\Events\IntegrationUpdated;
 use App\Domain\Integrations\IntegrationType;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
@@ -67,6 +68,11 @@ final class SyncWidget implements ShouldQueue
     public function handleIntegrationBlocked(IntegrationBlocked $integrationBlocked): void
     {
         $this->handle($integrationBlocked->id);
+    }
+
+    public function handleIntegrationUnblocked(IntegrationUnblocked $integrationUnblocked): void
+    {
+        $this->handle($integrationUnblocked->id);
     }
 
     public function handleIntegrationDeleted(IntegrationDeleted $integrationDeleted): void
@@ -184,6 +190,7 @@ final class SyncWidget implements ShouldQueue
             IntegrationCreated::class,
             IntegrationActivated::class,
             IntegrationBlocked::class,
+            IntegrationUnblocked::class,
             IntegrationDeleted::class,
             IntegrationUpdated::class => 'integration',
             ContactCreated::class => 'contact',

--- a/app/ProjectAanvraag/ProjectAanvraagServiceProvider.php
+++ b/app/ProjectAanvraag/ProjectAanvraagServiceProvider.php
@@ -11,6 +11,7 @@ use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Events\IntegrationDeleted;
+use App\Domain\Integrations\Events\IntegrationUnblocked;
 use App\Domain\Integrations\Events\IntegrationUpdated;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\ProjectAanvraag\Listeners\SyncWidget;
@@ -62,6 +63,7 @@ final class ProjectAanvraagServiceProvider extends ServiceProvider
 
             Event::listen(IntegrationActivated::class, [SyncWidget::class, 'handleIntegrationActivated']);
             Event::listen(IntegrationBlocked::class, [SyncWidget::class, 'handleIntegrationBlocked']);
+            Event::listen(IntegrationUnblocked::class, [SyncWidget::class, 'handleIntegrationUnblocked']);
             Event::listen(IntegrationDeleted::class, [SyncWidget::class, 'handleIntegrationDeleted']);
 
             Event::listen(IntegrationUpdated::class, [SyncWidget::class, 'handleIntegrationUpdated']);


### PR DESCRIPTION
### Added

- `IntegrationUnblocked`: new Event

### Changed

- `IntegrationModel`: dispatch new Event `IntegrationUnblocked` when performing an `unblock()`
- `SyncWidget`: added new function `handleIntegrationUnblocked()`
- `ProjectAanvraagServiceProvider`: listen to new Event `IntegrationUnblocked`

### Fixed

- an `unblock()`  also happens on `projectaanvraag`

### TODO

- unblock on `UiTID`, `KeyCloak`, `Auth0` & `Insightly`

---
Ticket: https://jira.publiq.be/browse/PPF-485
