### PR TITLE
PPF-493 Add client id to keycloakclient

### DIFF
--- a/app/Keycloak/CachedKeycloakClientStatus.php
+++ b/app/Keycloak/CachedKeycloakClientStatus.php
@@ -20,7 +20,7 @@ final class CachedKeycloakClientStatus
         $uuid = $client->id->toString();
 
         if(! isset($this->statuses[$uuid])) {
-            $this->statuses[$uuid] = $this->apiClient->fetchIsClientActive($client->realm, $client->integrationId);
+            $this->statuses[$uuid] = $this->apiClient->fetchIsClientActive($client);
         } else {
             $this->logger->info(self::class . '  - ' . $uuid . ': cache hit: ' . ($this->statuses[$uuid] ? 'Active' : 'Blocked'));
         }

--- a/app/Keycloak/Client.php
+++ b/app/Keycloak/Client.php
@@ -13,13 +13,18 @@ final readonly class Client
     public function __construct(
         public UuidInterface $id,
         public UuidInterface $integrationId,
+        public UuidInterface $clientId,
         public string $clientSecret,
         public Realm $realm,
     ) {
     }
 
-    public static function createFromJson(Realm $realm, UuidInterface $integrationId, array $data): self
-    {
+    public static function createFromJson(
+        Realm $realm,
+        UuidInterface $integrationId,
+        UuidInterface $clientId,
+        array $data
+    ): self {
         if (empty($data['secret'])) {
             throw new InvalidArgumentException('Missing secret');
         }
@@ -27,6 +32,7 @@ final readonly class Client
         return new self(
             Uuid::fromString($data['id']),
             $integrationId,
+            $clientId,
             $data['secret'],
             $realm,
         );

--- a/app/Keycloak/Client/ApiClient.php
+++ b/app/Keycloak/Client/ApiClient.php
@@ -17,7 +17,7 @@ interface ApiClient
 
     public function fetchClient(Realm $realm, Integration $integration, UuidInterface $clientId): Client;
 
-    public function fetchIsClientActive(Realm $realm, UuidInterface $integrationId): bool;
+    public function fetchIsClientActive(Client $client): bool;
 
     public function unblockClient(Client $client): void;
 

--- a/app/Keycloak/Client/ApiClient.php
+++ b/app/Keycloak/Client/ApiClient.php
@@ -11,11 +11,11 @@ use Ramsey\Uuid\UuidInterface;
 
 interface ApiClient
 {
-    public function createClient(Realm $realm, Integration $integration): void;
+    public function createClient(Realm $realm, Integration $integration, UuidInterface $clientId): void;
 
     public function addScopeToClient(Realm $realm, UuidInterface $clientId, UuidInterface $scopeId): void;
 
-    public function fetchClient(Realm $realm, Integration $integration): Client;
+    public function fetchClient(Realm $realm, Integration $integration, UuidInterface $clientId): Client;
 
     public function fetchIsClientActive(Realm $realm, UuidInterface $integrationId): bool;
 

--- a/app/Keycloak/Client/KeycloakApiClient.php
+++ b/app/Keycloak/Client/KeycloakApiClient.php
@@ -131,8 +131,6 @@ final readonly class KeycloakApiClient implements ApiClient
             $data = Json::decodeAssociatively($body);
             return Client::createFromJson($realm, $integration->id, $clientId, $data[0]);
         } catch (Throwable $e) {
-            Log::error($e->getLine() . '/' . $e->getMessage());
-
             throw KeyCloakApiFailed::failedToFetchClient($realm, $e->getMessage());
         }
     }

--- a/app/Keycloak/Converters/IntegrationToKeycloakClientConverter.php
+++ b/app/Keycloak/Converters/IntegrationToKeycloakClientConverter.php
@@ -10,12 +10,12 @@ use Ramsey\Uuid\UuidInterface;
 
 final class IntegrationToKeycloakClientConverter
 {
-    public static function convert(UuidInterface $id, Integration $integration): array
+    public static function convert(UuidInterface $id, Integration $integration, UuidInterface $clientId): array
     {
         return [
             'protocol' => 'openid-connect',
             'id' => $id->toString(),
-            'clientId' => $integration->id->toString(),
+            'clientId' => $clientId->toString(),
             'name' => $integration->name,
             'description' => $integration->description,
             'publicClient' => false,

--- a/app/Keycloak/Listeners/CreateClients.php
+++ b/app/Keycloak/Listeners/CreateClients.php
@@ -18,6 +18,7 @@ use App\Keycloak\ScopeConfig;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 
 final class CreateClients implements ShouldQueue
@@ -78,8 +79,10 @@ final class CreateClients implements ShouldQueue
 
         foreach ($realms as $realm) {
             try {
-                $this->client->createClient($realm, $integration);
-                $client = $this->client->fetchClient($realm, $integration);
+                $clientId = Uuid::uuid4();
+
+                $this->client->createClient($realm, $integration, $clientId);
+                $client = $this->client->fetchClient($realm, $integration, $clientId);
                 $this->client->addScopeToClient($realm, $client->id, $scopeId);
 
                 $clientCollection->add($client);

--- a/app/Keycloak/Listeners/UpdateClients.php
+++ b/app/Keycloak/Listeners/UpdateClients.php
@@ -64,7 +64,11 @@ final class UpdateClients implements ShouldQueue
         $this->client->updateClient(
             $keycloakClient,
             array_merge(
-                IntegrationToKeycloakClientConverter::convert($keycloakClient->id, $integration),
+                IntegrationToKeycloakClientConverter::convert(
+                    $keycloakClient->id,
+                    $integration,
+                    $keycloakClient->clientId
+                ),
                 IntegrationUrlConverter::convert($integration, $keycloakClient)
             )
         );
@@ -73,6 +77,7 @@ final class UpdateClients implements ShouldQueue
 
         $this->logger->info('Keycloak client updated', [
             'integration_id' => $integration->id->toString(),
+            'client_id' => $keycloakClient->clientId->toString(),
             'realm' => $keycloakClient->realm->internalName,
         ]);
     }

--- a/app/Keycloak/Models/KeycloakClientModel.php
+++ b/app/Keycloak/Models/KeycloakClientModel.php
@@ -32,6 +32,7 @@ final class KeycloakClientModel extends UuidModel
             // Trying to use magic getters for eg $this->id gives a 0 back
             Uuid::fromString($this->id),
             Uuid::fromString($this->integration_id),
+            Uuid::fromString($this->client_id),
             $this->client_secret,
             RealmCollection::fromInternalName($this->realm)
         );

--- a/app/Keycloak/Models/KeycloakClientModel.php
+++ b/app/Keycloak/Models/KeycloakClientModel.php
@@ -34,7 +34,7 @@ final class KeycloakClientModel extends UuidModel
             Uuid::fromString($this->integration_id),
             Uuid::fromString($this->client_id),
             $this->client_secret,
-            RealmCollection::fromInternalName($this->realm)
+            RealmCollection::fromPublicName($this->realm)
         );
     }
 

--- a/app/Keycloak/RealmCollection.php
+++ b/app/Keycloak/RealmCollection.php
@@ -27,6 +27,11 @@ final class RealmCollection extends Collection
             }
         }
 
+        /** @todo remove this later once we support multiple realms, this is only needed to fix some unit tests */
+        if ($publicName === Realm::getMasterRealm()->publicName) {
+            return Realm::getMasterRealm();
+        }
+
         throw new InvalidArgumentException('Invalid realm: ' . $publicName);
     }
 

--- a/app/Keycloak/RealmCollection.php
+++ b/app/Keycloak/RealmCollection.php
@@ -19,19 +19,15 @@ final class RealmCollection extends Collection
         return new self([new Realm('uitidpoc', 'Acceptance', Environment::Acceptance)]);
     }
 
-    public static function fromInternalName(string $internalName): Realm
+    public static function fromPublicName(string $publicName): Realm
     {
         foreach (self::getRealms() as $realm) {
-            if ($realm->internalName === $internalName) {
+            if ($realm->publicName === $publicName) {
                 return $realm;
             }
         }
 
-        if ($internalName === Realm::getMasterRealm()->internalName) {
-            return Realm::getMasterRealm();
-        }
-
-        throw new InvalidArgumentException('Invalid realm: ' . $internalName);
+        throw new InvalidArgumentException('Invalid realm: ' . $publicName);
     }
 
     /**
@@ -41,7 +37,7 @@ final class RealmCollection extends Collection
     {
         $output = [];
         foreach (self::getRealms() as $realm) {
-            $output[$realm->internalName] = $realm->publicName;
+            $output[$realm->publicName] = $realm->publicName;
         }
         return $output;
     }

--- a/app/Keycloak/Repositories/EloquentKeycloakClientRepository.php
+++ b/app/Keycloak/Repositories/EloquentKeycloakClientRepository.php
@@ -27,6 +27,7 @@ final class EloquentKeycloakClientRepository implements KeycloakClientRepository
                         [
                             'id' => $client->id->toString(),
                             'integration_id' => $client->integrationId->toString(),
+                            'client_id' => $client->clientId->toString(),
                             'client_secret' => $client->clientSecret,
                             'realm' => $client->realm->internalName,
                         ]

--- a/app/Keycloak/Repositories/EloquentKeycloakClientRepository.php
+++ b/app/Keycloak/Repositories/EloquentKeycloakClientRepository.php
@@ -29,7 +29,7 @@ final class EloquentKeycloakClientRepository implements KeycloakClientRepository
                             'integration_id' => $client->integrationId->toString(),
                             'client_id' => $client->clientId->toString(),
                             'client_secret' => $client->clientSecret,
-                            'realm' => $client->realm->internalName,
+                            'realm' => $client->realm->publicName,
                         ]
                     );
             }

--- a/app/Nova/Resources/KeycloakClient.php
+++ b/app/Nova/Resources/KeycloakClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Nova\Resources;
 
 use App\Keycloak\CachedKeycloakClientStatus;
+use App\Keycloak\Config;
 use App\Keycloak\Models\KeycloakClientModel;
 use App\Keycloak\RealmCollection;
 use App\Nova\ActionGuards\ActionGuard;
@@ -73,7 +74,7 @@ final class KeycloakClient extends Resource
                 return '<span style="color: green;">Active</span>';
             })->asHtml(),
             Text::make('client_id', function (KeycloakClientModel $model) {
-                return $model->toDomain()->integrationId->toString();
+                return $model->toDomain()->clientId->toString();
             })
                 ->readonly(),
             Text::make('client_secret')

--- a/database/migrations/2024_05_10_100641_create_keycloak_client_table.php
+++ b/database/migrations/2024_05_10_100641_create_keycloak_client_table.php
@@ -12,13 +12,14 @@ return new class () extends Migration {
         Schema::create('keycloak_clients', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->uuid('integration_id');
+            $table->uuid('client_id');
             $table->string('client_secret');
             $table->string('realm');
 
             $table->softDeletes();
             $table->timestamps();
 
-            $table->index('integration_id', 'realm');
+            $table->index('client_id', 'realm');
         });
     }
 

--- a/tests/Keycloak/CachedKeycloakClientStatusTest.php
+++ b/tests/Keycloak/CachedKeycloakClientStatusTest.php
@@ -35,7 +35,7 @@ final class CachedKeycloakClientStatusTest extends TestCase
     {
         $this->apiClient->expects($this->once())
             ->method('fetchIsClientActive')
-            ->with($this->client->realm, $this->client->integrationId)
+            ->with($this->client)
             ->willReturn(true);
 
         $receivedGrants = $this->cachedKeycloakClientStatus->isClientBlocked($this->client);

--- a/tests/Keycloak/CachedKeycloakClientStatusTest.php
+++ b/tests/Keycloak/CachedKeycloakClientStatusTest.php
@@ -28,7 +28,7 @@ final class CachedKeycloakClientStatusTest extends TestCase
 
         $this->apiClient = $this->createMock(ApiClient::class);
         $this->cachedKeycloakClientStatus = new CachedKeycloakClientStatus($this->apiClient, new NullLogger());
-        $this->client = new Client(Uuid::uuid4(), Uuid::uuid4(), 'client-id-1', Realm::getMasterRealm());
+        $this->client = new Client(Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), 'client-id-1', Realm::getMasterRealm());
     }
 
     public function test_does_cache_layer_work(): void

--- a/tests/Keycloak/Client/KeycloakApiClientTest.php
+++ b/tests/Keycloak/Client/KeycloakApiClientTest.php
@@ -224,7 +224,9 @@ final class KeycloakApiClientTest extends TestCase
             $this->logger
         );
 
-        $this->assertEquals($enabled, $apiClient->fetchIsClientActive($this->realm, $this->integration->id));
+        $client = new Client(Uuid::uuid4(), $this->integration->id, Uuid::uuid4(), 'my-secret', new Realm('uitidpoc', 'Acceptance', Environment::Acceptance));
+
+        $this->assertEquals($enabled, $apiClient->fetchIsClientActive($client));
     }
 
     public static function dataProviderIsClientEnabled(): array

--- a/tests/Keycloak/ClientTest.php
+++ b/tests/Keycloak/ClientTest.php
@@ -17,16 +17,18 @@ final class ClientTest extends TestCase
     {
         $realm = new Realm('uitidpoc', 'acceptance', Environment::Acceptance);
         $integrationId = Uuid::uuid4();
+        $clientId = Uuid::uuid4();
         $data = [
             'id' => Uuid::uuid4()->toString(),
             'secret' => 'testSecret',
         ];
 
-        $client = Client::createFromJson($realm, $integrationId, $data);
+        $client = Client::createFromJson($realm, $integrationId, $clientId, $data);
 
         $this->assertEquals($data['id'], $client->id->toString());
         $this->assertEquals($data['secret'], $client->clientSecret);
         $this->assertEquals($integrationId, $client->integrationId);
+        $this->assertEquals($clientId, $client->clientId);
         $this->assertEquals($realm, $client->realm);
     }
 
@@ -41,6 +43,6 @@ final class ClientTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        Client::createFromJson($realm, $integrationId, $data);
+        Client::createFromJson($realm, $integrationId, Uuid::uuid4(), $data);
     }
 }

--- a/tests/Keycloak/Converters/IntegrationToKeycloakClientConverterTest.php
+++ b/tests/Keycloak/Converters/IntegrationToKeycloakClientConverterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Keycloak\Service;
+namespace Tests\Keycloak\Converters;
 
 use App\Domain\Integrations\IntegrationPartnerStatus;
 use App\Keycloak\Converters\IntegrationToKeycloakClientConverter;
@@ -20,15 +20,16 @@ final class IntegrationToKeycloakClientConverterTest extends TestCase
     public function test_integration_converted_to_keycloak_format(IntegrationPartnerStatus $partnerStatus, bool $serviceAccountsEnabled, bool $standardFlowEnabled): void
     {
         $id = Uuid::uuid4();
+        $clientId = Uuid::uuid4();
 
         $integration = $this->givenThereIsAnIntegration($id, ['partnerStatus' => $partnerStatus]);
 
-        $convertedData = IntegrationToKeycloakClientConverter::convert($id, $integration);
+        $convertedData = IntegrationToKeycloakClientConverter::convert($id, $integration, $clientId);
 
         $this->assertIsArray($convertedData);
         $this->assertEquals('openid-connect', $convertedData['protocol']);
         $this->assertEquals($id->toString(), $convertedData['id']);
-        $this->assertEquals($integration->id->toString(), $convertedData['clientId']);
+        $this->assertEquals($clientId->toString(), $convertedData['clientId']);
         $this->assertEquals($integration->name, $convertedData['name']);
         $this->assertEquals($integration->description, $convertedData['description']);
         $this->assertEquals($serviceAccountsEnabled, $convertedData['serviceAccountsEnabled']);

--- a/tests/Keycloak/Converters/IntegrationUrlConverterTest.php
+++ b/tests/Keycloak/Converters/IntegrationUrlConverterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Keycloak\Service;
+namespace Tests\Keycloak\Converters;
 
 use App\Domain\Integrations\Environment;
 use App\Domain\Integrations\IntegrationPartnerStatus;
@@ -28,6 +28,7 @@ final class IntegrationUrlConverterTest extends TestCase
         $this->client = new Client(
             Uuid::uuid4(),
             $this->integrationId,
+            Uuid::uuid4(),
             'my-secret',
             new Realm('Acc', 'Acc', Environment::Acceptance)
         );

--- a/tests/Keycloak/Jobs/BlockClientHandlerTest.php
+++ b/tests/Keycloak/Jobs/BlockClientHandlerTest.php
@@ -28,6 +28,7 @@ final class BlockClientHandlerTest extends TestCase
         $client = new Client(
             Uuid::uuid4(),
             Uuid::uuid4(),
+            Uuid::uuid4(),
             'client-secret-1',
             Realm::getMasterRealm()
         );
@@ -57,6 +58,7 @@ final class BlockClientHandlerTest extends TestCase
     public function test_handler_fails_when_client_does_not_exists(): void
     {
         $client = new Client(
+            Uuid::uuid4(),
             Uuid::uuid4(),
             Uuid::uuid4(),
             'client-secret-1',

--- a/tests/Keycloak/Jobs/UnblockClientHandlerTest.php
+++ b/tests/Keycloak/Jobs/UnblockClientHandlerTest.php
@@ -29,6 +29,7 @@ final class UnblockClientHandlerTest extends TestCase
         $client = new Client(
             Uuid::uuid4(),
             Uuid::uuid4(),
+            Uuid::uuid4(),
             'client-secret-1',
             Realm::getMasterRealm()
         );
@@ -58,6 +59,7 @@ final class UnblockClientHandlerTest extends TestCase
     public function test_handler_fails_when_client_does_not_exists(): void
     {
         $client = new Client(
+            Uuid::uuid4(),
             Uuid::uuid4(),
             Uuid::uuid4(),
             'client-secret-1',

--- a/tests/Keycloak/Listeners/BlockClientsTest.php
+++ b/tests/Keycloak/Listeners/BlockClientsTest.php
@@ -58,7 +58,7 @@ final class BlockClientsTest extends TestCase
 
         $clients = [];
         foreach ($this->config->realms as $realm) {
-            $client = new Client(Uuid::uuid4(), $this->integration->id, self::SECRET, $realm);
+            $client = new Client(Uuid::uuid4(), $this->integration->id, Uuid::uuid4(), self::SECRET, $realm);
 
             $this->apiClient->expects($this->once())
                 ->method('blockClient')

--- a/tests/Keycloak/Listeners/CreateClientsTest.php
+++ b/tests/Keycloak/Listeners/CreateClientsTest.php
@@ -81,6 +81,7 @@ final class CreateClientsTest extends TestCase
             $clients[$realm->internalName] = new Client(
                 Uuid::uuid4(),
                 $this->integration->id,
+                Uuid::uuid4(),
                 self::SECRET,
                 $realm
             );
@@ -206,6 +207,7 @@ final class CreateClientsTest extends TestCase
                     $client = new Client(
                         $clientIds[$realm->internalName],
                         $integration->id,
+                        Uuid::uuid4(),
                         self::SECRET,
                         $realm
                     );

--- a/tests/Keycloak/Listeners/UpdateClientsTest.php
+++ b/tests/Keycloak/Listeners/UpdateClientsTest.php
@@ -81,14 +81,14 @@ final class UpdateClientsTest extends TestCase
 
         $clients = [];
         foreach ($this->config->realms as $realm) {
-            $client = new Client(Uuid::uuid4(), $this->integration->id, self::SECRET, $realm);
+            $client = new Client(Uuid::uuid4(), $this->integration->id, Uuid::uuid4(), self::SECRET, $realm);
 
             $this->apiClient->expects($this->once())
                 ->method('updateClient')
                 ->with(
                     $client,
                     array_merge(
-                        IntegrationToKeycloakClientConverter::convert($client->id, $this->integration),
+                        IntegrationToKeycloakClientConverter::convert($client->id, $this->integration, $client->clientId),
                         IntegrationUrlConverter::convert($this->integration, $client)
                     )
                 );
@@ -105,6 +105,7 @@ final class UpdateClientsTest extends TestCase
                 ->with('Keycloak client updated', [
                     'integration_id' => $this->integration->id->toString(),
                     'realm' => $client->realm->internalName,
+                    'client_id' => $client->clientId->toString(),
                 ]);
 
             $clients[] = $client;

--- a/tests/Keycloak/Repositories/EloquentKeycloakClientRepositoryTest.php
+++ b/tests/Keycloak/Repositories/EloquentKeycloakClientRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Keycloak\Repositories;
 
+use App\Domain\Integrations\Environment;
 use App\Keycloak\Client;
 use App\Keycloak\Realm;
 use App\Keycloak\RealmCollection;
@@ -50,17 +51,19 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
         );
         $this->repository->create($client1, $client2);
 
+        $realm = new Realm('uitidpoc', 'Acceptance', Environment::Acceptance);
+
         $this->assertDatabaseHas('keycloak_clients', [
             'integration_id' => $integrationId->toString(),
             'client_secret' => 'client-secret-1',
             'client_id' => $clientId->toString(),
-            'realm' => Realm::getMasterRealm()->internalName,
+            'realm' => Realm::getMasterRealm()->publicName,
         ]);
         $this->assertDatabaseHas('keycloak_clients', [
             'integration_id' => $integrationId->toString(),
             'client_secret' => 'client-secret-2',
             'client_id' => $clientId2->toString(),
-            'realm' => $realm->internalName,
+            'realm' => $realm->publicName,
         ]);
     }
 
@@ -106,7 +109,7 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
 
         /** @var Realm $realm */
         $realm = RealmCollection::getRealms()->first();
-        $realms = [Realm::getMasterRealm(), $realm];
+        $realms = [new Realm('uitidpoc', 'Acceptance', Environment::Acceptance), $realm];
 
         $clients = [];
 

--- a/tests/Keycloak/Repositories/EloquentKeycloakClientRepositoryTest.php
+++ b/tests/Keycloak/Repositories/EloquentKeycloakClientRepositoryTest.php
@@ -31,16 +31,20 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
         $realm = RealmCollection::getRealms()->first();
 
         $integrationId = Uuid::uuid4();
+        $clientId = Uuid::uuid4();
+        $clientId2 = Uuid::uuid4();
 
         $client1 = new Client(
             Uuid::uuid4(),
             $integrationId,
+            $clientId,
             'client-secret-1',
             Realm::getMasterRealm()
         );
         $client2 = new Client(
             Uuid::uuid4(),
             $integrationId,
+            $clientId2,
             'client-secret-2',
             $realm
         );
@@ -49,11 +53,13 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
         $this->assertDatabaseHas('keycloak_clients', [
             'integration_id' => $integrationId->toString(),
             'client_secret' => 'client-secret-1',
+            'client_id' => $clientId->toString(),
             'realm' => Realm::getMasterRealm()->internalName,
         ]);
         $this->assertDatabaseHas('keycloak_clients', [
             'integration_id' => $integrationId->toString(),
             'client_secret' => 'client-secret-2',
+            'client_id' => $clientId2->toString(),
             'realm' => $realm->internalName,
         ]);
     }
@@ -64,16 +70,20 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
         $realm = RealmCollection::getRealms()->first();
 
         $integrationId = Uuid::uuid4();
+        $clientId = Uuid::uuid4();
+        $clientId2 = Uuid::uuid4();
 
         $client1 = new Client(
             Uuid::uuid4(),
             $integrationId,
+            $clientId,
             'client-secret-1',
             $realm
         );
         $client2 = new Client(
             Uuid::uuid4(),
             $integrationId,
+            $clientId2,
             'client-secret-1',
             Realm::getMasterRealm()
         );
@@ -107,6 +117,7 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
                 $clients[] = new Client(
                     Uuid::uuid4(),
                     $integrationId,
+                    Uuid::uuid4(),
                     'client-secret-' . $count,
                     $realm
                 );
@@ -139,6 +150,7 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
                 $clients[] = new Client(
                     Uuid::uuid4(),
                     $integrationId,
+                    Uuid::uuid4(),
                     'client-secret-' . $count,
                     $realm
                 );
@@ -177,6 +189,7 @@ final class EloquentKeycloakClientRepositoryTest extends TestCase
             $clients[] = new Client(
                 Uuid::uuid4(),
                 $integrationId,
+                Uuid::uuid4(),
                 'client-secret',
                 $realm
             );

--- a/tests/Nova/ActionGuards/Keycloak/BlockKeycloakClientGuardTest.php
+++ b/tests/Nova/ActionGuards/Keycloak/BlockKeycloakClientGuardTest.php
@@ -38,7 +38,7 @@ final class BlockKeycloakClientGuardTest extends TestCase
     {
         $this->apiClient->expects($this->once())
             ->method('fetchIsClientActive')
-            ->with($this->client->realm, $this->client->integrationId)
+            ->with($this->client)
             ->willReturn($isEnabled);
 
         $this->assertEquals($canDisable, $this->guard->canDo($this->client));

--- a/tests/Nova/ActionGuards/Keycloak/BlockKeycloakClientGuardTest.php
+++ b/tests/Nova/ActionGuards/Keycloak/BlockKeycloakClientGuardTest.php
@@ -30,7 +30,7 @@ final class BlockKeycloakClientGuardTest extends TestCase
 
         $this->apiClient = $this->createMock(ApiClient::class);
         $this->guard = new BlockKeycloakClientGuard(new CachedKeycloakClientStatus($this->apiClient, new NullLogger()));
-        $this->client = new Client(Uuid::uuid4(), Uuid::uuid4(), 'client-id-1', Realm::getMasterRealm());
+        $this->client = new Client(Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), 'client-id-1', Realm::getMasterRealm());
     }
 
     #[DataProvider('dataProvider')]

--- a/tests/Nova/ActionGuards/Keycloak/UnblockKeycloakClientGuardTest.php
+++ b/tests/Nova/ActionGuards/Keycloak/UnblockKeycloakClientGuardTest.php
@@ -38,7 +38,7 @@ final class UnblockKeycloakClientGuardTest extends TestCase
     {
         $this->apiClient->expects($this->once())
             ->method('fetchIsClientActive')
-            ->with($this->client->realm, $this->client->integrationId)
+            ->with($this->client)
             ->willReturn($isEnabled);
 
         $this->assertEquals($canEnable, $this->guard->canDo($this->client));

--- a/tests/Nova/ActionGuards/Keycloak/UnblockKeycloakClientGuardTest.php
+++ b/tests/Nova/ActionGuards/Keycloak/UnblockKeycloakClientGuardTest.php
@@ -30,7 +30,7 @@ final class UnblockKeycloakClientGuardTest extends TestCase
 
         $this->apiClient = $this->createMock(ApiClient::class);
         $this->guard = new UnblockKeycloakClientGuard(new CachedKeycloakClientStatus($this->apiClient, new NullLogger()));
-        $this->client = new Client(Uuid::uuid4(), Uuid::uuid4(), 'client-id-1', Realm::getMasterRealm());
+        $this->client = new Client(Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), 'client-id-1', Realm::getMasterRealm());
     }
 
     #[DataProvider('dataProvider')]


### PR DESCRIPTION
### Changed
In preparation of the bigger work of this ticket, I added a separate client_id and integration_id for all the keycloak clients.
This will allow us to have more than 1 client per integration on a single realm.


---
Ticket: https://jira.uitdatabank.be/browse/PPF-493
