### PR TITLE
PPF-485 unblock on UiTID

### DIFF
--- a/app/UiTiDv1/Listeners/UnblockConsumers.php
+++ b/app/UiTiDv1/Listeners/UnblockConsumers.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UiTiDv1\Listeners;
+
+use App\Domain\Integrations\Events\IntegrationUnblocked;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1ClusterSDK;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+final class UnblockConsumers implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly UiTiDv1ClusterSDK $clusterSDK,
+        private readonly UiTiDv1ConsumerRepository $consumerRepository,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function handle(IntegrationUnblocked $integrationUnblocked): void
+    {
+        $consumers = $this->consumerRepository->getByIntegrationId($integrationUnblocked->id);
+
+        $integration = $this->integrationRepository->getById($integrationUnblocked->id);
+        $this->clusterSDK->unblockConsumers($integration, ... $consumers);
+
+        $this->logger->info(
+            'UiTiD v1 consumer(s) unblocked',
+            [
+                'domain' => 'uitid',
+                'integration_id' => $integrationUnblocked->id->toString(),
+            ]
+        );
+    }
+
+    public function failed(IntegrationUnblocked $integrationUnblocked, Throwable $throwable): void
+    {
+        $this->logger->error('Failed to unblock UiTiD v1 consumer(s)', [
+            'integration_id' => $integrationUnblocked->id->toString(),
+            'exception' => $throwable,
+        ]);
+    }
+}

--- a/app/UiTiDv1/UiTiDv1ServiceProvider.php
+++ b/app/UiTiDv1/UiTiDv1ServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\UiTiDv1;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
+use App\Domain\Integrations\Events\IntegrationUnblocked;
 use App\Domain\Integrations\Events\IntegrationUpdated;
 use App\UiTiDv1\Jobs\UnblockConsumer;
 use App\UiTiDv1\Jobs\UnblockConsumerHandler;
@@ -15,6 +16,7 @@ use App\UiTiDv1\Jobs\CreateMissingConsumers;
 use App\UiTiDv1\Jobs\CreateMissingConsumersHandler;
 use App\UiTiDv1\Listeners\BlockConsumers;
 use App\UiTiDv1\Listeners\CreateConsumers;
+use App\UiTiDv1\Listeners\UnblockConsumers;
 use App\UiTiDv1\Listeners\UpdateConsumers;
 use App\UiTiDv1\Repositories\EloquentUiTiDv1ConsumerRepository;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
@@ -76,6 +78,7 @@ final class UiTiDv1ServiceProvider extends ServiceProvider
             Event::listen(CreateMissingConsumers::class, [CreateMissingConsumersHandler::class, 'handle']);
             Event::listen(IntegrationUpdated::class, [UpdateConsumers::class, 'handle']);
             Event::listen(IntegrationBlocked::class, [BlockConsumers::class, 'handle']);
+            Event::listen(IntegrationUnblocked::class, [UnblockConsumers::class, 'handle']);
 
             Event::listen(UnblockConsumer::class, [UnblockConsumerHandler::class, 'handle']);
             Event::listen(BlockConsumer::class, [BlockConsumerHandler::class, 'handle']);

--- a/tests/UiTiDv1/Listeners/UnblockConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/UnblockConsumersTest.php
@@ -4,12 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\UiTiDv1\Listeners;
 
+use App\Domain\Integrations\Events\IntegrationUnblocked;
+use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationPartnerStatus;
+use App\Domain\Integrations\IntegrationStatus;
+use App\Domain\Integrations\IntegrationType;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\UiTiDv1\Listeners\UnblockConsumers;
 use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use App\UiTiDv1\UiTiDv1Consumer;
+use App\UiTiDv1\UiTiDv1Environment;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\NullLogger;
+use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
 
@@ -40,6 +51,98 @@ final class UnblockConsumersTest extends TestCase
 
     public function test_it_can_unblock_consumers(): void
     {
+        $integrationId = Uuid::uuid4();
 
+        $integration = new Integration(
+            $integrationId,
+            IntegrationType::EntryApi,
+            'dummy',
+            'This is a dummy',
+            Uuid::uuid4(),
+            IntegrationStatus::Blocked,
+            IntegrationPartnerStatus::THIRD_PARTY
+        );
+
+        $consumers = [
+            new UiTiDv1Consumer(
+                Uuid::uuid4(),
+                $integrationId,
+                '4135',
+                'mock-consumer-key-1',
+                'mock-consumer-secret-1',
+                'mock-api-key-1',
+                UiTiDv1Environment::Acceptance
+            ),
+            new UiTiDv1Consumer(
+                Uuid::uuid4(),
+                $integrationId,
+                '4136',
+                'mock-consumer-key-2',
+                'mock-consumer-secret-2',
+                'mock-api-key-2',
+                UiTiDv1Environment::Testing
+            ),
+            new UiTiDv1Consumer(
+                Uuid::uuid4(),
+                $integrationId,
+                '4137',
+                'mock-consumer-key-3',
+                'mock-consumer-secret-3',
+                'mock-api-key-3',
+                UiTiDv1Environment::Production
+            ),
+        ];
+
+        $this->consumerRepository
+            ->expects($this->once())
+            ->method('getByIntegrationId')
+            ->with($integrationId)
+            ->willReturn($consumers);
+
+        $this->integrationRepository
+            ->expects($this->once())
+            ->method('getById')
+            ->with($integrationId)
+            ->willReturn($integration);
+
+        $this->httpClient
+            ->expects($this->exactly(3))
+            ->method('request')
+            ->willReturnCallback(
+                fn (string $actualMethod, string $actualUri) =>
+                match ([$actualMethod, $actualUri]) {
+                    [
+                        'POST',
+                        'serviceconsumer/mock-consumer-key-1',
+                        /*[
+                            'http_errors' => false,
+                            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                            'body' => 'status=ACTIVE&group=1&group=2',
+                        ],*/
+                    ],
+                    [
+                        'POST',
+                        'serviceconsumer/mock-consumer-key-2',
+                        /*[
+                            'http_errors' => false,
+                            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                            'body' => 'status=ACTIVE&group=1&group=2',
+                        ],*/
+                    ],
+                    [
+                        'POST',
+                        'serviceconsumer/mock-consumer-key-3',
+                        /*[
+                            'http_errors' => false,
+                            'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
+                            'body' => 'status=ACTIVE&group=1&group=2',
+                        ],*/
+                    ] => new Response(200, [], ''),
+                    default => throw new \LogicException('Invalid arguments received'),
+                }
+            );
+
+
+        $this->unblockConsumers->handle(new IntegrationUnblocked($integrationId));
     }
 }

--- a/tests/UiTiDv1/Listeners/UnblockConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/UnblockConsumersTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\UiTiDv1\Listeners;
+
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\UiTiDv1\Listeners\UnblockConsumers;
+use App\UiTiDv1\Repositories\UiTiDv1ConsumerRepository;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+use Tests\UiTiDv1\CreatesMockUiTiDv1ClusterSDK;
+
+final class UnblockConsumersTest extends TestCase
+{
+    use CreatesMockUiTiDv1ClusterSDK;
+
+    private ClientInterface&MockObject $httpClient;
+
+    private UiTiDv1ConsumerRepository&MockObject $consumerRepository;
+
+    private IntegrationRepository&MockObject $integrationRepository;
+    private UnblockConsumers $unblockConsumers;
+
+    public function setUp(): void
+    {
+        $this->httpClient = $this->createMock(ClientInterface::class);
+        $this->consumerRepository = $this->createMock(UiTiDv1ConsumerRepository::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
+
+        $this->unblockConsumers = new UnblockConsumers(
+            $this->createMockUiTiDv1ClusterSDK($this->httpClient),
+            $this->consumerRepository,
+            $this->integrationRepository,
+            new NullLogger()
+        );
+    }
+
+    public function test_it_can_unblock_consumers(): void
+    {
+
+    }
+}

--- a/tests/UiTiDv1/Listeners/UnblockConsumersTest.php
+++ b/tests/UiTiDv1/Listeners/UnblockConsumersTest.php
@@ -16,9 +16,7 @@ use App\UiTiDv1\UiTiDv1Consumer;
 use App\UiTiDv1\UiTiDv1Environment;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
-use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Http\Message\RequestInterface;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
@@ -109,34 +107,34 @@ final class UnblockConsumersTest extends TestCase
             ->expects($this->exactly(3))
             ->method('request')
             ->willReturnCallback(
-                fn (string $actualMethod, string $actualUri) =>
-                match ([$actualMethod, $actualUri]) {
+                fn (string $actualMethod, string $actualUri, array $actualOptions) =>
+                match ([$actualMethod, $actualUri, $actualOptions]) {
                     [
                         'POST',
                         'serviceconsumer/mock-consumer-key-1',
-                        /*[
+                        [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
                             'body' => 'status=ACTIVE&group=1&group=2',
-                        ],*/
+                        ],
                     ],
                     [
                         'POST',
                         'serviceconsumer/mock-consumer-key-2',
-                        /*[
+                        [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'status=ACTIVE&group=1&group=2',
-                        ],*/
+                            'body' => 'status=ACTIVE&group=7&group=8',
+                        ],
                     ],
                     [
                         'POST',
                         'serviceconsumer/mock-consumer-key-3',
-                        /*[
+                        [
                             'http_errors' => false,
                             'headers' => ['content-type' => 'application/x-www-form-urlencoded'],
-                            'body' => 'status=ACTIVE&group=1&group=2',
-                        ],*/
+                            'body' => 'status=ACTIVE&group=13&group=14',
+                        ],
                     ] => new Response(200, [], ''),
                     default => throw new \LogicException('Invalid arguments received'),
                 }


### PR DESCRIPTION
### Added

- `UnblockConsumers`: Add listener for `IntegrationUnblocked` for `UiTID` + Unit Test

### Changed

- `UiTiDv1ServiceProvider`: Listen to `IntegrationUnblocked`

### Fixed

- `Consumers` are now unblocked on `UiTID`

---
Ticket: https://jira.publiq.be/browse/PPF-485
