### PR TITLE
PPF-523 Deleting integration should block keycloak clients

### DIFF
--- a/app/Keycloak/KeycloakServiceProvider.php
+++ b/app/Keycloak/KeycloakServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Keycloak;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
+use App\Domain\Integrations\Events\IntegrationDeleted;
 use App\Domain\Integrations\Events\IntegrationUnblocked;
 use App\Domain\Integrations\Events\IntegrationUpdated;
 use App\Domain\Integrations\Events\IntegrationUrlCreated;
@@ -74,6 +75,7 @@ final class KeycloakServiceProvider extends ServiceProvider
         Event::listen(IntegrationUpdated::class, [UpdateClients::class, 'handle']);
         Event::listen(IntegrationBlocked::class, [BlockClients::class, 'handle']);
         Event::listen(IntegrationUnblocked::class, [UnblockClients::class, 'handle']);
+        Event::listen(IntegrationDeleted::class, [BlockClients::class, 'handle']);
 
         Event::listen(MissingClientsDetected::class, [CreateClients::class, 'handleCreatingMissingClients']);
 

--- a/app/Keycloak/Listeners/BlockClients.php
+++ b/app/Keycloak/Listeners/BlockClients.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Keycloak\Listeners;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
+use App\Domain\Integrations\Events\IntegrationDeleted;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Keycloak\Client\ApiClient;
 use App\Keycloak\Exception\KeyCloakApiFailed;
@@ -26,7 +27,7 @@ final class BlockClients implements ShouldQueue
     ) {
     }
 
-    public function handle(IntegrationBlocked $integrationBlocked): void
+    public function handle(IntegrationBlocked|IntegrationDeleted $integrationBlocked): void
     {
         $integration = $this->integrationRepository->getById($integrationBlocked->id);
         $keycloakClients = $this->keycloakClientRepository->getByIntegrationId($integrationBlocked->id);
@@ -46,7 +47,7 @@ final class BlockClients implements ShouldQueue
         }
     }
 
-    public function failed(IntegrationBlocked $integrationBlocked, Throwable $throwable): void
+    public function failed(IntegrationBlocked|IntegrationDeleted $integrationBlocked, Throwable $throwable): void
     {
         $this->logger->error('Failed to block Keycloak client(s)', [
             'integration_id' => $integrationBlocked->id->toString(),

--- a/tests/Keycloak/Listeners/BlockClientsTest.php
+++ b/tests/Keycloak/Listeners/BlockClientsTest.php
@@ -95,7 +95,7 @@ final class BlockClientsTest extends TestCase
         $createClients->handle($event);
     }
 
-    public static function differentWaysToBlockClients() : array
+    public static function differentWaysToBlockClients(): array
     {
         return [
             [new IntegrationBlocked(Uuid::fromString(self::INTEGRATION_ID))],

--- a/tests/Keycloak/Listeners/BlockClientsTest.php
+++ b/tests/Keycloak/Listeners/BlockClientsTest.php
@@ -6,8 +6,6 @@ namespace Tests\Keycloak\Listeners;
 
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationDeleted;
-use App\Domain\Integrations\Integration;
-use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Keycloak\Client;
 use App\Keycloak\Client\ApiClient;
 use App\Keycloak\Listeners\BlockClients;
@@ -29,7 +27,6 @@ final class BlockClientsTest extends TestCase
     private const SECRET = 'my-secret';
     private const INTEGRATION_ID = '3f2c8aa3-6d5d-4a72-ba41-ab26bc8e591d';
 
-    private Integration $integration;
     private ApiClient&MockObject $apiClient;
     private LoggerInterface&MockObject $logger;
 
@@ -37,28 +34,20 @@ final class BlockClientsTest extends TestCase
     {
         parent::setUp();
 
-        // This is a search API integration
-        $this->integration = $this->givenThereIsAnIntegration(Uuid::fromString(self::INTEGRATION_ID));
-
         $this->apiClient = $this->createMock(ApiClient::class);
         $this->logger = $this->createMock(LoggerInterface::class);
     }
 
     /**
-     *@dataProvider differentWaysToBlockClients
+     * @dataProvider differentWaysToBlockClients
      */
     public function test_block_clients_when_integration_is_blocked_or_deleted(IntegrationBlocked|IntegrationDeleted $event): void
     {
-        $integrationRepository = $this->createMock(IntegrationRepository::class);
-        $integrationRepository->expects($this->once())
-            ->method('getById')
-            ->with($this->integration->id)
-            ->willReturn($this->integration);
+        $integrationId = Uuid::fromString(self::INTEGRATION_ID);
 
         $clients = [];
-        foreach ($this->givenAllRealms()
-                 as $realm) {
-            $client = new Client(Uuid::uuid4(), $this->integration->id, Uuid::uuid4()->toString(), self::SECRET, $realm->environment);
+        foreach ($this->givenAllRealms() as $realm) {
+            $client = new Client(Uuid::uuid4(), $integrationId, Uuid::uuid4()->toString(), self::SECRET, $realm->environment);
 
             $clients[$client->id->toString()] = $client;
         }
@@ -76,17 +65,16 @@ final class BlockClientsTest extends TestCase
                 $this->assertArrayHasKey('integration_id', $options);
                 $this->assertArrayHasKey('environment', $options);
 
-                $this->assertEquals($this->integration->id->toString(), $options['integration_id']);
+                $this->assertEquals(self::INTEGRATION_ID, $options['integration_id']);
             });
 
         $keycloakClientRepository = $this->createMock(KeycloakClientRepository::class);
         $keycloakClientRepository->expects($this->once())
             ->method('getByIntegrationId')
-            ->with($this->integration->id)
+            ->with($integrationId)
             ->willReturn($clients);
 
         $createClients = new BlockClients(
-            $integrationRepository,
             $keycloakClientRepository,
             $this->apiClient,
             $this->logger


### PR DESCRIPTION
### Added
- Deleting integration now blocks keycloak clients

### Changed
BlockClients no longer fetches the integration but just uses the integration id.
- It was not needed anyway, nothing except the id is used
- It broke the delete integration flow because at that point the repository no longer finds the resource because it is deleted!

---
Ticket: https://jira.uitdatabank.be/browse/PPF-523 