### PR TITLE
PPF-520 Bugfix - Missing client scope for Entry API integrations

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -161,7 +161,6 @@ KEYCLOAK_ACC_CLIENT_SECRET='super-secret'
 # Incorrect values, but need to contain a valid UUID formatted string
 KEYCLOAK_ACC_SCOPE_SEARCH_API_ID='06059529-74b5-422a-a499-ffcaf065d437' #publiq-api-sapi-scope
 KEYCLOAK_ACC_SCOPE_ENTRY_API_ID='d8a54568-26da-412b-a441-d5e2fad84478' #publiq-api-entry-scope
-KEYCLOAK_ACC_SCOPE_WIDGETS_ID='123ae05d-1c41-40c8-8716-c4654a3bfd98'#publiq-widget-scope
 KEYCLOAK_ACC_SCOPE_UITPAS_ID='bcfb28cc-454f-488a-b080-6a29d9c0158e'#uitpas-scope
 
 KEYCLOAK_TEST_BASE_URL='https://account.kcpoc.lodgon.com/'
@@ -172,7 +171,6 @@ KEYCLOAK_TEST_CLIENT_SECRET='super-secret'
 # Incorrect values, but need to contain a valid UUID formatted string
 KEYCLOAK_TEST_SCOPE_SEARCH_API_ID='06059529-74b5-422a-a499-ffcaf065d437' #publiq-api-sapi-scope
 KEYCLOAK_TEST_SCOPE_ENTRY_API_ID='d8a54568-26da-412b-a441-d5e2fad84478' #publiq-api-entry-scope
-KEYCLOAK_TEST_SCOPE_WIDGETS_ID='123ae05d-1c41-40c8-8716-c4654a3bfd98'#publiq-widget-scope
 KEYCLOAK_TEST_SCOPE_UITPAS_ID='bcfb28cc-454f-488a-b080-6a29d9c0158e'#uitpas-scope
 
 KEYCLOAK_PROD_BASE_URL='https://account.kcpoc.lodgon.com/'
@@ -183,7 +181,6 @@ KEYCLOAK_PROD_CLIENT_SECRET='super-secret'
 # Incorrect values, but need to contain a valid UUID formatted string
 KEYCLOAK_PROD_SCOPE_SEARCH_API_ID='06059529-74b5-422a-a499-ffcaf065d437' #publiq-api-sapi-scope
 KEYCLOAK_PROD_SCOPE_ENTRY_API_ID='d8a54568-26da-412b-a441-d5e2fad84478' #publiq-api-entry-scope
-KEYCLOAK_PROD_SCOPE_WIDGETS_ID='123ae05d-1c41-40c8-8716-c4654a3bfd98'#publiq-widget-scope
 KEYCLOAK_PROD_SCOPE_UITPAS_ID='bcfb28cc-454f-488a-b080-6a29d9c0158e'#uitpas-scope
 
 SEARCH_BASE_URI=https://search-acc.uitdatabank.be/

--- a/app/Keycloak/Listeners/CreateClients.php
+++ b/app/Keycloak/Listeners/CreateClients.php
@@ -78,10 +78,13 @@ final class CreateClients implements ShouldQueue
         foreach ($realms as $realm) {
             try {
                 $client = $this->client->createClient($realm, $integration, new ClientIdUuidStrategy());
-                $this->client->addScopeToClient(
-                    $client,
-                    $realm->scopeConfig->getScopeIdFromIntegrationType($integration)
-                );
+
+                foreach($realm->scopeConfig->getScopeIdsFromIntegrationType($integration) as $scopeId) {
+                    $this->client->addScopeToClient(
+                        $client,
+                        $scopeId
+                    );
+                }
 
                 $clientCollection->add($client);
             } catch (KeyCloakApiFailed $e) {

--- a/app/Keycloak/Listeners/UpdateClients.php
+++ b/app/Keycloak/Listeners/UpdateClients.php
@@ -48,7 +48,7 @@ final class UpdateClients implements ShouldQueue
                 $this->updateClient(
                     $integration,
                     $keycloakClient,
-                    $realm->scopeConfig->getScopeIdFromIntegrationType($integration)
+                    $realm->scopeConfig->getScopeIdsFromIntegrationType($integration)
                 );
             } catch (KeyCloakApiFailed $e) {
                 $this->failed($event, $e);
@@ -64,7 +64,10 @@ final class UpdateClients implements ShouldQueue
         ]);
     }
 
-    private function updateClient(Integration $integration, Client $keycloakClient, UuidInterface $scopeId): void
+    /**
+     * @param UuidInterface[] $scopeIds
+     */
+    private function updateClient(Integration $integration, Client $keycloakClient, array $scopeIds): void
     {
         $this->client->updateClient(
             $keycloakClient,
@@ -78,7 +81,9 @@ final class UpdateClients implements ShouldQueue
             )
         );
         $this->client->deleteScopes($keycloakClient);
-        $this->client->addScopeToClient($keycloakClient, $scopeId);
+        foreach($scopeIds as $scopeId) {
+            $this->client->addScopeToClient($keycloakClient, $scopeId);
+        }
 
         $this->logger->info('Keycloak client updated', [
             'integration_id' => $integration->id->toString(),

--- a/app/Keycloak/Realms.php
+++ b/app/Keycloak/Realms.php
@@ -33,7 +33,6 @@ final class Realms extends Collection
                 new ScopeConfig(
                     Uuid::fromString($environment['scope']['search_api_id']),
                     Uuid::fromString($environment['scope']['entry_api_id']),
-                    Uuid::fromString($environment['scope']['widgets_id']),
                     Uuid::fromString($environment['scope']['uitpas_id'])
                 )
             ));

--- a/app/Keycloak/ScopeConfig.php
+++ b/app/Keycloak/ScopeConfig.php
@@ -13,18 +13,17 @@ final readonly class ScopeConfig
     public function __construct(
         public UuidInterface $searchApiScopeId,
         public UuidInterface $entryApiScopeId,
-        public UuidInterface $widgetScopeId,
         public UuidInterface $uitpasScopeId,
     ) {
     }
 
-    public function getScopeIdFromIntegrationType(Integration $integration): UuidInterface
+    /** @return UuidInterface[] */
+    public function getScopeIdsFromIntegrationType(Integration $integration): array
     {
         return match ($integration->type) {
-            IntegrationType::EntryApi => $this->entryApiScopeId,
-            IntegrationType::Widgets => $this->widgetScopeId,
-            IntegrationType::SearchApi => $this->searchApiScopeId,
-            IntegrationType::UiTPAS => $this->uitpasScopeId
+            IntegrationType::Widgets, IntegrationType::SearchApi => [$this->searchApiScopeId],
+            IntegrationType::EntryApi => [$this->entryApiScopeId, $this->searchApiScopeId],
+            IntegrationType::UiTPAS => [$this->uitpasScopeId, $this->entryApiScopeId, $this->searchApiScopeId]
         };
     }
 
@@ -34,7 +33,6 @@ final readonly class ScopeConfig
         return [
             $this->searchApiScopeId,
             $this->entryApiScopeId,
-            $this->widgetScopeId,
             $this->uitpasScopeId,
         ];
     }

--- a/tests/Keycloak/RealmFactory.php
+++ b/tests/Keycloak/RealmFactory.php
@@ -14,7 +14,6 @@ trait RealmFactory
 {
     protected const SEARCH_SCOPE_ID = '06059529-74b5-422a-a499-ffcaf065d437';
     protected const ENTRY_SCOPE_ID = 'd8a54568-26da-412b-a441-d5e2fad84478';
-    protected const WIDGET_SCOPE_ID = '123ae05d-1c41-40c8-8716-c4654a3bfd98';
     protected const UITPAS_SCOPE_ID = '0743b1c7-0ea2-46af-906e-fbb6c0317514';
 
     public function givenAllRealms(): Realms
@@ -70,7 +69,6 @@ trait RealmFactory
         return new ScopeConfig(
             Uuid::fromString(self::SEARCH_SCOPE_ID),
             Uuid::fromString(self::ENTRY_SCOPE_ID),
-            Uuid::fromString(self::WIDGET_SCOPE_ID),
             Uuid::fromString(self::UITPAS_SCOPE_ID),
         );
     }

--- a/tests/Keycloak/RealmsTest.php
+++ b/tests/Keycloak/RealmsTest.php
@@ -20,19 +20,16 @@ final class RealmsTest extends TestCase
             Environment::Acceptance->value => [
                 'search_api_id' => Uuid::uuid4()->toString(),
                 'entry_api_id' => Uuid::uuid4()->toString(),
-                'widgets_id' => Uuid::uuid4()->toString(),
                 'uitpas_id' => Uuid::uuid4()->toString(),
             ],
             Environment::Testing->value => [
                 'search_api_id' => Uuid::uuid4()->toString(),
                 'entry_api_id' => Uuid::uuid4()->toString(),
-                'widgets_id' => Uuid::uuid4()->toString(),
                 'uitpas_id' => Uuid::uuid4()->toString(),
             ],
             Environment::Production->value => [
                 'search_api_id' => Uuid::uuid4()->toString(),
                 'entry_api_id' => Uuid::uuid4()->toString(),
-                'widgets_id' => Uuid::uuid4()->toString(),
                 'uitpas_id' => Uuid::uuid4()->toString(),
             ],
         ];
@@ -80,7 +77,6 @@ final class RealmsTest extends TestCase
             $this->assertInstanceOf(ScopeConfig::class, $realm->scopeConfig);
             $this->assertEquals($scopes[$environment->value]['search_api_id'], $realm->scopeConfig->searchApiScopeId->toString());
             $this->assertEquals($scopes[$environment->value]['entry_api_id'], $realm->scopeConfig->entryApiScopeId->toString());
-            $this->assertEquals($scopes[$environment->value]['widgets_id'], $realm->scopeConfig->widgetScopeId->toString());
             $this->assertEquals($scopes[$environment->value]['uitpas_id'], $realm->scopeConfig->uitpasScopeId->toString());
         }
     }

--- a/tests/Keycloak/ScopeConfigTest.php
+++ b/tests/Keycloak/ScopeConfigTest.php
@@ -16,7 +16,6 @@ final class ScopeConfigTest extends TestCase
 
     private const SEARCH_API_ID = '41255857-b8ad-44ce-9a17-db72540461b7';
     private const ENTRY_API_ID = '824c09c0-2f3a-4fa0-bde2-8bf25c9a5b74';
-    private const WIDGETS_ID = 'deb654ab-1324-48ca-9931-1485a456c916';
     private const UITPAS_ID = '0743b1c7-0ea2-46af-906e-fbb6c0317514';
 
     private ScopeConfig $scopeConfig;
@@ -28,7 +27,6 @@ final class ScopeConfigTest extends TestCase
         $this->scopeConfig = new ScopeConfig(
             Uuid::fromString(self::SEARCH_API_ID),
             Uuid::fromString(self::ENTRY_API_ID),
-            Uuid::fromString(self::WIDGETS_ID),
             Uuid::fromString(self::UITPAS_ID)
         );
     }
@@ -36,22 +34,22 @@ final class ScopeConfigTest extends TestCase
     /**
      * @dataProvider integrationDataProvider
      */
-    public function test_get_scope_id_from_integration(IntegrationType $type, string $expectedScopeId): void
+    public function test_get_scope_ids_from_integration(IntegrationType $type, array $expectedScopeId): void
     {
-        $actualScopeId = $this->scopeConfig->getScopeIdFromIntegrationType(
+        $actualScopeIds = $this->scopeConfig->getScopeIdsFromIntegrationType(
             $this->givenThereIsAnIntegration(Uuid::uuid4(), ['type' => $type])
         );
 
-        $this->assertEquals($expectedScopeId, $actualScopeId->toString());
+        $this->assertEquals($expectedScopeId, $actualScopeIds);
     }
 
     public static function integrationDataProvider(): array
     {
         return [
-            [IntegrationType::SearchApi, self::SEARCH_API_ID],
-            [IntegrationType::EntryApi, self::ENTRY_API_ID],
-            [IntegrationType::Widgets, self::WIDGETS_ID],
-            [IntegrationType::UiTPAS, self::UITPAS_ID],
+            [IntegrationType::SearchApi, [Uuid::fromString(self::SEARCH_API_ID)]],
+            [IntegrationType::EntryApi, [Uuid::fromString(self::ENTRY_API_ID), Uuid::fromString(self::SEARCH_API_ID)]],
+            [IntegrationType::Widgets, [Uuid::fromString(self::SEARCH_API_ID)]],
+            [IntegrationType::UiTPAS, [Uuid::fromString(self::UITPAS_ID), Uuid::fromString(self::ENTRY_API_ID), Uuid::fromString(self::SEARCH_API_ID)]],
         ];
     }
 }


### PR DESCRIPTION
### Fixed
- Made it possible for specific types of clients to have multiple scopes assigned to it.
- Entry API -> has now -> Entry api scope + sapi3 scope
- Uitpas scope -> has now -> Entry api scope + sapi3 scope + uitpas scope

### Removed
- Widgets do not have its own scope, so I removed this and replaced it with SAPI3 scope.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-520
