### PR TITLE
PPF-525 Changed payload create client Keycloak

### DIFF
--- a/app/Keycloak/Client/KeycloakApiClient.php
+++ b/app/Keycloak/Client/KeycloakApiClient.php
@@ -47,7 +47,8 @@ final readonly class KeycloakApiClient implements ApiClient
                     Json::encode(IntegrationToKeycloakClientConverter::convert(
                         $id,
                         $integration,
-                        $clientId
+                        $clientId,
+                        $realm->environment
                     ))
                 ),
                 $realm

--- a/app/Keycloak/Converters/IntegrationToKeycloakClientConverter.php
+++ b/app/Keycloak/Converters/IntegrationToKeycloakClientConverter.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Keycloak\Converters;
 
+use App\Domain\Integrations\Environment;
 use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\IntegrationPartnerStatus;
 use Ramsey\Uuid\UuidInterface;
 
 final class IntegrationToKeycloakClientConverter
 {
-    public static function convert(UuidInterface $id, Integration $integration, string $clientId): array
+    public static function convert(UuidInterface $id, Integration $integration, string $clientId, Environment $environment): array
     {
         return [
             'protocol' => 'openid-connect',
@@ -26,6 +27,18 @@ final class IntegrationToKeycloakClientConverter
             'standardFlowEnabled' => $integration->partnerStatus === IntegrationPartnerStatus::FIRST_PARTY,
             'frontchannelLogout' => true,
             'alwaysDisplayInConsole' => false,
+            'attributes' => [
+                'origin' => 'publiq-platform',
+                'use.refresh.tokens' => true,
+                'post.logout.redirect.uris' => IntegrationUrlConverter::buildLogoutUrls($integration, $environment),
+            ],
+            'baseUrl' => IntegrationUrlConverter::buildLoginUrl($integration, $environment),
+            'redirectUris' => IntegrationUrlConverter::buildCallbackUrls($integration, $environment),
+            'webOrigins' => [
+                '+', // This permits all origins of Valid Redirect URIs for CORS checks
+                'https://docs.publiq.be', // Always add this origin to enable CORS requests from the "Try it out!" functionality in Stoplight
+                'https://publiq.stoplight.io', // Always add this origin to enable CORS requests from the "Try it out!" functionality in Stoplight
+            ],
         ];
     }
 }

--- a/app/Keycloak/Listeners/UpdateClients.php
+++ b/app/Keycloak/Listeners/UpdateClients.php
@@ -12,11 +12,10 @@ use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Keycloak\Client;
 use App\Keycloak\Client\ApiClient;
+use App\Keycloak\Converters\IntegrationToKeycloakClientConverter;
 use App\Keycloak\Exception\KeyCloakApiFailed;
 use App\Keycloak\Realms;
 use App\Keycloak\Repositories\KeycloakClientRepository;
-use App\Keycloak\Converters\IntegrationToKeycloakClientConverter;
-use App\Keycloak\Converters\IntegrationUrlConverter;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
@@ -71,17 +70,15 @@ final class UpdateClients implements ShouldQueue
     {
         $this->client->updateClient(
             $keycloakClient,
-            array_merge(
-                IntegrationToKeycloakClientConverter::convert(
-                    $keycloakClient->id,
-                    $integration,
-                    $keycloakClient->clientId
-                ),
-                IntegrationUrlConverter::convert($integration, $keycloakClient)
+            IntegrationToKeycloakClientConverter::convert(
+                $keycloakClient->id,
+                $integration,
+                $keycloakClient->clientId,
+                $keycloakClient->environment
             )
         );
         $this->client->deleteScopes($keycloakClient);
-        foreach($scopeIds as $scopeId) {
+        foreach ($scopeIds as $scopeId) {
             $this->client->addScopeToClient($keycloakClient, $scopeId);
         }
 

--- a/tests/Keycloak/Converters/IntegrationToKeycloakClientConverterTest.php
+++ b/tests/Keycloak/Converters/IntegrationToKeycloakClientConverterTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Keycloak\Converters;
 
+use App\Domain\Integrations\Environment;
 use App\Domain\Integrations\IntegrationPartnerStatus;
+use App\Domain\Integrations\IntegrationUrl;
+use App\Domain\Integrations\IntegrationUrlType;
 use App\Keycloak\Converters\IntegrationToKeycloakClientConverter;
-use Tests\TestCase;
 use Ramsey\Uuid\Uuid;
 use Tests\CreatesIntegration;
+use Tests\TestCase;
 
 final class IntegrationToKeycloakClientConverterTest extends TestCase
 {
@@ -24,7 +27,7 @@ final class IntegrationToKeycloakClientConverterTest extends TestCase
 
         $integration = $this->givenThereIsAnIntegration($id, ['partnerStatus' => $partnerStatus]);
 
-        $convertedData = IntegrationToKeycloakClientConverter::convert($id, $integration, $clientId);
+        $convertedData = IntegrationToKeycloakClientConverter::convert($id, $integration, $clientId, Environment::Acceptance);
 
         $this->assertIsArray($convertedData);
         $this->assertEquals('openid-connect', $convertedData['protocol']);
@@ -40,6 +43,18 @@ final class IntegrationToKeycloakClientConverterTest extends TestCase
         $this->assertFalse($convertedData['directAccessGrantsEnabled']);
         $this->assertFalse($convertedData['alwaysDisplayInConsole']);
         $this->assertTrue($convertedData['frontchannelLogout']);
+        $this->assertEquals([
+            'origin' => 'publiq-platform',
+            'use.refresh.tokens' => true,
+            'post.logout.redirect.uris' => '',
+        ], $convertedData['attributes']);
+        $this->assertEquals('', $convertedData['baseUrl']);
+        $this->assertEquals([], $convertedData['redirectUris']);
+        $this->assertEquals([
+            '+',
+            'https://docs.publiq.be',
+            'https://publiq.stoplight.io',
+        ], $convertedData['webOrigins']);
     }
 
     public static function integrationDataProvider(): array
@@ -48,5 +63,29 @@ final class IntegrationToKeycloakClientConverterTest extends TestCase
             [IntegrationPartnerStatus::THIRD_PARTY, true, false],
             [IntegrationPartnerStatus::FIRST_PARTY, false, true],
         ];
+    }
+
+    public function test_combining_keycloak_convert_with_configured_uris(): void
+    {
+        $id = Uuid::uuid4();
+        $clientId = Uuid::uuid4()->toString();
+
+        $integration = $this->givenThereIsAnIntegration($id, ['partnerStatus' => IntegrationPartnerStatus::FIRST_PARTY]);
+        $integration = $integration->withUrls(
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Logout, 'https://example.com/logout1'),
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Logout, 'https://example.com/logout2'),
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Callback, 'https://example.com/callback1'),
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Callback, 'https://example.com/callback2'),
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Login, 'https://example.com/login1'),
+        );
+
+        $convertedData = IntegrationToKeycloakClientConverter::convert($id, $integration, $clientId, Environment::Acceptance);
+        $this->assertEquals([
+            'origin' => 'publiq-platform',
+            'use.refresh.tokens' => true,
+            'post.logout.redirect.uris' => 'https://example.com/logout1#https://example.com/logout2',
+        ], $convertedData['attributes']);
+        $this->assertEquals('https://example.com/login1', $convertedData['baseUrl']);
+        $this->assertEquals(['https://example.com/callback1', 'https://example.com/callback2'], $convertedData['redirectUris']);
     }
 }

--- a/tests/Keycloak/Converters/IntegrationUrlConverterTest.php
+++ b/tests/Keycloak/Converters/IntegrationUrlConverterTest.php
@@ -43,46 +43,64 @@ final class IntegrationUrlConverterTest extends TestCase
     {
         $integration = $this->givenThereIsAnIntegration($this->integrationId, ['partnerStatus' => IntegrationPartnerStatus::THIRD_PARTY]);
 
-        $result = IntegrationUrlConverter::convert($integration, $this->client);
+        $result = IntegrationUrlConverter::buildLoginUrl($integration, $this->client->environment);
+        $this->assertSame('', $result);
 
-        $expected = [
-            'baseUrl' => '',
-            'redirectUris' => [],
-            'attributes' => ['post.logout.redirect.uris' => ''],
-            'webOrigins' => ['+'],
-        ];
+        $result = IntegrationUrlConverter::buildCallbackUrls($integration, $this->client->environment);
+        $this->assertSame([], $result);
 
-        $this->assertSame($expected, $result);
+        $result = IntegrationUrlConverter::buildLogoutUrls($integration, $this->client->environment);
+        $this->assertSame('', $result);
     }
 
-    public function test_convert_for_first_party(): void
+    public function test_convert_for_first_party_login_url(): void
     {
         $integration = $this->givenThereIsAnIntegration($this->integrationId, ['partnerStatus' => IntegrationPartnerStatus::FIRST_PARTY]);
         $integration = $integration->withUrls(
             new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Login, 'https://example.com/login1'),
+            // These urls below should NOT be shown! Wrong Realm
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Testing, IntegrationUrlType::Login, 'https://wrong.com/'),
+            // You can only have 1 login uri
             new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Login, 'https://example.com/login2'),
+        );
+
+        $this->assertSame(
+            'https://example.com/login1',
+            IntegrationUrlConverter::buildLoginUrl($integration, $this->client->environment)
+        );
+    }
+
+    public function test_convert_for_first_party_callback_urls(): void
+    {
+        $integration = $this->givenThereIsAnIntegration($this->integrationId, ['partnerStatus' => IntegrationPartnerStatus::FIRST_PARTY]);
+        $integration = $integration->withUrls(
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Callback, 'https://example.com/callback1'),
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Callback, 'https://example.com/callback2'),
+
+            // These urls below should NOT be shown! Wrong Realm
+            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Production, IntegrationUrlType::Callback, 'https://wrong.com/'),
+        );
+        $result = IntegrationUrlConverter::buildCallbackUrls($integration, $this->client->environment);
+
+        $this->assertSame([
+            'https://example.com/callback1',
+            'https://example.com/callback2',
+        ], $result);
+    }
+
+    public function test_convert_for_first_party_logout_urls(): void
+    {
+        $integration = $this->givenThereIsAnIntegration($this->integrationId, ['partnerStatus' => IntegrationPartnerStatus::FIRST_PARTY]);
+        $integration = $integration->withUrls(
             new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Logout, 'https://example.com/logout1'),
             new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Logout, 'https://example.com/logout2'),
-            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Callback, 'https://example.com/callback'),
 
-            // These urls below should NOT be shown!
+            // These urls below should NOT be shown! Wrong Realm
             new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Production, IntegrationUrlType::Logout, 'https://wrong.com/'),
-            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Testing, IntegrationUrlType::Login, 'https://wrong.com/'),
-            // You can only have 1 callback uri
-            new IntegrationUrl(Uuid::uuid4(), $integration->id, Environment::Acceptance, IntegrationUrlType::Callback, 'https://wrong.com/')
         );
-        $result = IntegrationUrlConverter::convert($integration, $this->client);
-
-        $expected = [
-            'baseUrl' => 'https://example.com/callback',
-            'redirectUris' => [
-                'https://example.com/login1',
-                'https://example.com/login2',
-            ],
-            'attributes' => ['post.logout.redirect.uris' => 'https://example.com/logout1#https://example.com/logout2'],
-            'webOrigins' => ['+'],
-        ];
-
-        $this->assertSame($expected, $result);
+        $this->assertSame(
+            'https://example.com/logout1#https://example.com/logout2',
+            IntegrationUrlConverter::buildLogoutUrls($integration, $this->client->environment)
+        );
     }
 }

--- a/tests/Keycloak/Listeners/UpdateClientsTest.php
+++ b/tests/Keycloak/Listeners/UpdateClientsTest.php
@@ -16,7 +16,6 @@ use App\Keycloak\Listeners\UpdateClients;
 use App\Keycloak\Realms;
 use App\Keycloak\Repositories\KeycloakClientRepository;
 use App\Keycloak\Converters\IntegrationToKeycloakClientConverter;
-use App\Keycloak\Converters\IntegrationUrlConverter;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -79,10 +78,7 @@ final class UpdateClientsTest extends TestCase
         $this->apiClient->expects($this->exactly($this->realms->count()))
             ->method('updateClient')
             ->willReturnCallback(function (Client $client, array $body) use (&$activeId) {
-                $expectedBody = array_merge(
-                    IntegrationToKeycloakClientConverter::convert($client->id, $this->integration, $client->clientId),
-                    IntegrationUrlConverter::convert($this->integration, $client)
-                );
+                $expectedBody = IntegrationToKeycloakClientConverter::convert($client->id, $this->integration, $client->clientId, $client->environment);
 
                 $this->assertEquals($expectedBody, $body);
 


### PR DESCRIPTION
We need to sent a slight different payload to Keycloak to create a client, based on feedback from Erwin and Corneel.

### Added
- Add https://docs.publiq.be/ / https://publiq.stoplight.io/ to allow web origins (CORS)
- Add hidden attribute "origin" to "publiq-platform" -> this will be used later to clear test clients (discussed with Erwin)
- Set  'use.refresh.tokens' => true (discussed with Erwin)
- Added extra test to see that the IntegrationToKeycloakClientConverter & IntegrationUrlConverter play well together

### Fixed
- BUGFIX Switch Login and Callback URL, you can only have 1 login url but multiple callback urls

---
Ticket: https://jira.uitdatabank.be/browse/PPF-525
