### PR TITLE
HOTFIX: Check if both auth0 & keycloak are enabled.

### DIFF
--- a/app/Auth0/Auth0ServiceProvider.php
+++ b/app/Auth0/Auth0ServiceProvider.php
@@ -93,7 +93,7 @@ final class Auth0ServiceProvider extends ServiceProvider
             );
         });
 
-        if (config(KeycloakConfig::KEYCLOAK_CREATION_ENABLED)) {
+        if (config(KeycloakConfig::KEYCLOAK_CREATION_ENABLED) || config('auth0.enabled')) {
             // By default, the Auth0 integration is enabled. For testing purposes this can be disabled inside the .env file.
 
             // May always be registered even if there are no configured tenants, because in that case the cluster SDK will


### PR DESCRIPTION
### Changed

- `Auth0ServiceProvider`: Check if either `Keycloak` or `auth0` is enabled to create Clients.

### Fixed

- Environments who are still on `auth0` can again create Clients.

---
Ticket: https://jira.publiq.be/browse/PPF-547