### PR TITLE
PPF-553 BUGFIX Organizers gives 409 in admin panel

### DIFF
--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -67,6 +67,7 @@ final class IntegrationModel extends UuidModel
     protected $attributes = [
         'status' => IntegrationStatus::Draft,
         'partner_status' => IntegrationPartnerStatus::THIRD_PARTY,
+        'type' => IntegrationType::UiTPAS->value,
     ];
 
     public function canBeActivated(): bool


### PR DESCRIPTION
### Fixed
The UiTdatabank organizers linked to an UiTPAS integration do not load in the admin panel. (409 error).
The problem is that on this API call the $resource is not loaded in the IntegrationModel (aka the fields).
This means that the method isUitpas() always returns false, because the $type is not set.

As a (quick) fix I set the default value of type to Uitpas.
On the UI overview pages the Integration is loaded in, so this overwrites the default value.

Know problem: When creating an integration in the Admin UI the Type is as a default Uitpas

Known Limitation: If we ever have 2 different values in type that toggle conditions, we have a problem.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-553 
