### PR TITLE
PPF-555 For uitpas integration always use key visibility v2

### DIFF
--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -7,6 +7,8 @@ namespace App\Domain\Integrations\Repositories;
 use App\Domain\Contacts\Models\ContactModel;
 use App\Domain\Coupons\Models\CouponModel;
 use App\Domain\Integrations\Integration;
+use App\Domain\Integrations\IntegrationType;
+use App\Domain\Integrations\KeyVisibility;
 use App\Domain\Integrations\Models\IntegrationModel;
 use App\Pagination\PaginatedCollection;
 use App\Pagination\PaginationInfo;
@@ -148,6 +150,11 @@ final class EloquentIntegrationRepository implements IntegrationRepository
         DB::transaction(function () use ($integration, $couponCode): void {
             if ($couponCode) {
                 $this->useCouponOnIntegration($integration->id, $couponCode);
+            }
+
+            // https://jira.publiq.be/browse/PPF-555
+            if($integration->type === IntegrationType::UiTPAS) {
+                $integration = $integration->withKeyVisibility(KeyVisibility::v2);
             }
 
             IntegrationModel::query()->create([

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -561,4 +561,28 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             'partner_status' => IntegrationPartnerStatus::FIRST_PARTY,
         ]);
     }
+
+    // https://jira.publiq.be/browse/PPF-555
+    public function test_it_can_save_integration_uitpas_always_with_key_visibility_v2(): void
+    {
+        $integrationId = Uuid::uuid4();
+
+        $searchIntegration = new Integration(
+            $integrationId,
+            IntegrationType::UiTPAS,
+            'First party integration',
+            'First party integration',
+            Uuid::uuid4(),
+            IntegrationStatus::Draft,
+            IntegrationPartnerStatus::FIRST_PARTY,
+        );
+        $searchIntegration = $searchIntegration->withKeyVisibility(KeyVisibility::v1);
+
+        $this->integrationRepository->save($searchIntegration);
+
+        $this->assertDatabaseHas('integrations', [
+            'id' => $integrationId,
+            'key_visibility' => 'v2',
+        ]);
+    }
 }


### PR DESCRIPTION
### Changed
For UiTPAS API integration, the key visiblity must always be v2
As discussed with Corneel, this is only changed for Integrations created in the frontend.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-555 