### PR TITLE
PPF-567 Ability to not create production client if base url is empty.

### DIFF
--- a/app/Keycloak/Realms.php
+++ b/app/Keycloak/Realms.php
@@ -13,7 +13,7 @@ use Ramsey\Uuid\Uuid;
  */
 final class Realms extends Collection
 {
-    public function __construct(array $realms=[])
+    public function __construct(array $realms = [])
     {
         parent::__construct($realms);
     }
@@ -23,6 +23,10 @@ final class Realms extends Collection
         $realms = new self();
 
         foreach (config('keycloak.environments') as $publicName => $environment) {
+            if ($environment['base_url'] === '') {
+                continue;
+            }
+
             $realms->add(new Realm(
                 $environment['internalName'],
                 ucfirst($publicName),

--- a/tests/Keycloak/RealmsTest.php
+++ b/tests/Keycloak/RealmsTest.php
@@ -34,7 +34,6 @@ final class RealmsTest extends TestCase
             ],
         ];
 
-        // Arrange
         Config::set('keycloak.environments', [
             Environment::Acceptance->value => [
                 'internalName' => 'internal_name_0',
@@ -79,5 +78,18 @@ final class RealmsTest extends TestCase
             $this->assertEquals($scopes[$environment->value]['entry_api_id'], $realm->scopeConfig->entryApiScopeId->toString());
             $this->assertEquals($scopes[$environment->value]['uitpas_id'], $realm->scopeConfig->uitpasScopeId->toString());
         }
+    }
+
+    public function testSkipEmptyEnvironments(): void
+    {
+        Config::set('keycloak.environments', [
+            Environment::Acceptance->value => [
+                'base_url' => '',
+            ],
+        ]);
+
+        $realms = Realms::build();
+
+        $this->assertCount(0, $realms);
     }
 }


### PR DESCRIPTION
### Changed
- Ability to not create production client if base url is empty.
This is required for the Keycloak run on Test Env, because there will not be a production env for Keycloak yet at that point in time.
---
Ticket: https://jira.uitdatabank.be/browse/PPF-567
