### PR TITLE
Ensure locale detection ignores non-locale path fragments

### DIFF
--- a/resources/ts/i18n/initializeI18n.ts
+++ b/resources/ts/i18n/initializeI18n.ts
@@ -23,6 +23,8 @@ export const initializeI18n = async () => {
         detection: {
           lookupCookie: "locale",
           order: ["path", "cookie"],
+          convertDetectedLanguage: (lng: string) =>
+            ["en", "nl"].includes(lng) ? lng : "",
         },
       });
 


### PR DESCRIPTION
### Fixed
- Fixed locale detection not ignoring non-locale path fragments

---

The URL detector in `i18next-browser-languagedetector` actually uses any first path fragment present when trying to find the language, so going to `/admin/somefakeurl` will try to set `admin` as locale, which hits the Widget validation logic as it should

Ticket: https://jira.publiq.be/browse/PPF-568
