### PR TITLE
PPF-610 PHPUnit deprecation fixes

### DIFF
--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Tests\TestCase;
@@ -702,7 +703,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
         );
     }
 
-    /** @dataProvider dataProviderGetIntegrationsThatHaveNotBeenActivatedYet */
+    #[DataProvider('dataProviderGetIntegrationsThatHaveNotBeenActivatedYet')]
     public function test_get_integrations_that_have_not_been_activated_yet(
         IntegrationType $integrationType,
         IntegrationStatus $status,

--- a/tests/Domain/KeyVisibilityUpgrades/Repositories/EloquentKeyVisibilityUpgradeRepositoryTest.php
+++ b/tests/Domain/KeyVisibilityUpgrades/Repositories/EloquentKeyVisibilityUpgradeRepositoryTest.php
@@ -24,10 +24,7 @@ final class EloquentKeyVisibilityUpgradeRepositoryTest extends TestCase
         $this->keyVisibilityUpgradeRepository = new EloquentKeyVisibilityUpgradeRepository();
     }
 
-    /**
-     * @test
-     */
-    public function it_can_create_a_key_visibility_upgrade(): void
+    public function test_it_can_create_a_key_visibility_upgrade(): void
     {
         $upgradeRequest = new KeyVisibilityUpgrade(
             Uuid::uuid4(),

--- a/tests/Domain/Mail/MailManagerTest.php
+++ b/tests/Domain/Mail/MailManagerTest.php
@@ -22,6 +22,7 @@ use App\Domain\Mail\MailManager;
 use App\Mails\Template\TemplateName;
 use App\Mails\Template\Templates;
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Mime\Address;
@@ -114,9 +115,7 @@ final class MailManagerTest extends TestCase
             ->withContacts(...$this->contacts);
     }
 
-    /**
-     * @dataProvider mailDataProvider
-     */
+    #[DataProvider('mailDataProvider')]
     public function testSendMail(
         object $event,
         string $method,

--- a/tests/Keycloak/Client/KeycloakApiClientTest.php
+++ b/tests/Keycloak/Client/KeycloakApiClientTest.php
@@ -14,6 +14,7 @@ use App\Keycloak\Exception\KeyCloakApiFailed;
 use App\Keycloak\Realm;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -144,7 +145,7 @@ final class KeycloakApiClientTest extends TestCase
         );
     }
 
-    /** @dataProvider dataProviderIsClientEnabled */
+    #[DataProvider('dataProviderIsClientEnabled')]
     public function test_fetch_is_client_enabled(bool $enabled): void
     {
         $mock = new MockHandler([

--- a/tests/Keycloak/Converters/IntegrationToKeycloakClientConverterTest.php
+++ b/tests/Keycloak/Converters/IntegrationToKeycloakClientConverterTest.php
@@ -9,6 +9,7 @@ use App\Domain\Integrations\IntegrationPartnerStatus;
 use App\Domain\Integrations\IntegrationUrl;
 use App\Domain\Integrations\IntegrationUrlType;
 use App\Keycloak\Converters\IntegrationToKeycloakClientConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
 use Tests\CreatesIntegration;
 use Tests\TestCase;
@@ -17,9 +18,7 @@ final class IntegrationToKeycloakClientConverterTest extends TestCase
 {
     use CreatesIntegration;
 
-    /**
-     * @dataProvider integrationDataProvider
-     */
+    #[DataProvider('integrationDataProvider')]
     public function test_integration_converted_to_keycloak_format(IntegrationPartnerStatus $partnerStatus, bool $serviceAccountsEnabled, bool $standardFlowEnabled): void
     {
         $id = Uuid::uuid4();

--- a/tests/Keycloak/Listeners/BlockClientsTest.php
+++ b/tests/Keycloak/Listeners/BlockClientsTest.php
@@ -10,6 +10,7 @@ use App\Keycloak\Client;
 use App\Keycloak\Client\ApiClient;
 use App\Keycloak\Listeners\BlockClients;
 use App\Keycloak\Repositories\KeycloakClientRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -38,9 +39,7 @@ final class BlockClientsTest extends TestCase
         $this->logger = $this->createMock(LoggerInterface::class);
     }
 
-    /**
-     * @dataProvider differentWaysToBlockClients
-     */
+    #[DataProvider('differentWaysToBlockClients')]
     public function test_block_clients_when_integration_is_blocked_or_deleted(IntegrationBlocked|IntegrationDeleted $event): void
     {
         $integrationId = Uuid::fromString(self::INTEGRATION_ID);

--- a/tests/Keycloak/ScopeConfigTest.php
+++ b/tests/Keycloak/ScopeConfigTest.php
@@ -6,6 +6,7 @@ namespace Tests\Keycloak;
 
 use App\Domain\Integrations\IntegrationType;
 use App\Keycloak\ScopeConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Ramsey\Uuid\Uuid;
 use Tests\CreatesIntegration;
@@ -31,9 +32,7 @@ final class ScopeConfigTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider integrationDataProvider
-     */
+    #[DataProvider('integrationDataProvider')]
     public function test_get_scope_ids_from_integration(IntegrationType $type, array $expectedScopeId): void
     {
         $actualScopeIds = $this->scopeConfig->getScopeIdsFromIntegrationType(


### PR DESCRIPTION
### Changed

- `tests/*`: Replaced all `dataProviders` in `DocBlocks`
- `test/*`: Replace 1 occurence of `@test` in `DocBlock`

### Fixed

- No more deprecation Warnings, when running the Unit tests.

---
Ticket: https://jira.publiq.be/browse/PPF-610
