### PR TITLE
Do not use the legacy flag to enable keycloak, use correct KeycloakCo…

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Keycloak\KeycloakConfig;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Middleware;
@@ -39,8 +40,8 @@ final class HandleInertiaRequests extends Middleware
                     'enabled' => config('uitpas.enabled'),
                 ],
                 'keycloak' => [
-                    'enabled' => config('keycloak.enabled'),
-                    'testClientEnabled' => config('keycloak.testClientEnabled'),
+                    'enabled' => config(KeycloakConfig::KEYCLOAK_LOGIN_ENABLED),
+                    'testClientEnabled' => config(KeycloakConfig::KEYCLOAK_LOGIN_TEST_CLIENT_ENABLED),
                 ],
             ],
             'widgetConfig' => [

--- a/app/Keycloak/KeycloakConfig.php
+++ b/app/Keycloak/KeycloakConfig.php
@@ -12,4 +12,5 @@ final class KeycloakConfig
     public const KEYCLOAK_CLIENT_ID = 'keycloak.login.clientId';
     public const KEYCLOAK_REALM_NAME = 'keycloak.login.realmName';
     public const KEYCLOAK_LOGIN_PARAMETERS = 'keycloak.login.parameters';
+    public const KEYCLOAK_LOGIN_TEST_CLIENT_ENABLED = 'keycloak.login.testClientEnabled';
 }


### PR DESCRIPTION
### Changed
The frontend still used the legacy "keycloak_enabled" flag which was split up in a "keycloak_login_enabled" and a "keycloak_client_creation_enabled" flag.
To prevent these types of errors I added use of the KeycloakConfig object.