### PR TITLE
PPF-608 hide UiTIDv1 consumer_key & consumer_secret in Nova

### DIFF
--- a/app/Nova/Resources/UiTiDv1.php
+++ b/app/Nova/Resources/UiTiDv1.php
@@ -76,10 +76,6 @@ final class UiTiDv1 extends Resource
                     $status->name
                 );
             })->asHtml(),
-            Text::make('consumer_key')
-                ->readonly(),
-            Text::make('consumer_secret')
-                ->readonly(),
             Text::make('api_key')
                 ->readonly(),
             Text::make('Open', function ($model) {


### PR DESCRIPTION
### Changed

- `Nova/Resources/UiTiDv1`: Do not show `consumerKey` & `consumerSecret`

### Fixed

- `UiTIDv1` `consumerKey` & `consumerSecret` are hidden in the Nova Admin panel.

---
Ticket: https://jira.publiq.be/browse/PPF-608
