### PR TITLE
PPF-611 Change reminder email to only sent mail under 1 year old

### DIFF
--- a/app/Console/Commands/SearchExpiredIntegrations.php
+++ b/app/Console/Commands/SearchExpiredIntegrations.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 
 final class SearchExpiredIntegrations extends Command
 {
+    private const ONE_YEAR = 12;
     protected $signature = 'integration:search-expired-integrations {--force : Skip confirmation prompt}';
 
     protected $description = 'Search for expired integrations and dispatch event';
@@ -30,9 +31,10 @@ final class SearchExpiredIntegrations extends Command
         $integrations = new Collection();
         foreach ($this->expirationTimers as $integrationType => $expirationTimer) {
             $integrations = $integrations->merge(
-                $this->integrationRepository->getDraftsByTypeAndOlderThenMonthsAgo(
+                $this->integrationRepository->getDraftsByTypeAndBetweenMonthsOld(
                     IntegrationType::from($integrationType),
-                    $expirationTimer
+                    $expirationTimer,
+                    self::ONE_YEAR
                 )
             );
         }

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationRepository.php
@@ -57,14 +57,14 @@ final class EloquentIntegrationRepository implements IntegrationRepository
     }
 
     /** @return Collection<Integration> */
-    public function getDraftsByTypeAndOlderThenMonthsAgo(IntegrationType $type, int $months): Collection
+    public function getDraftsByTypeAndBetweenMonthsOld(IntegrationType $type, int $startMonths, int $endMonths): Collection
     {
         return IntegrationModel::query()
             ->distinct()
             ->where('status', 'draft')
             ->where('type', $type->value)
             ->whereNull('reminder_email_sent')
-            ->where('created_at', '<', Carbon::now()->subMonths($months))
+            ->whereBetween('created_at', [Carbon::now()->subMonths($endMonths), Carbon::now()->subMonths($startMonths)])
             ->has('contacts')  // This ensures that only integrations with at least one contact are returned
             ->get()
             ->map(static function (IntegrationModel $integrationModel) {

--- a/app/Domain/Integrations/Repositories/IntegrationRepository.php
+++ b/app/Domain/Integrations/Repositories/IntegrationRepository.php
@@ -33,5 +33,5 @@ interface IntegrationRepository
     public function approve(UuidInterface $id): void;
 
     /** @return Collection<Integration> */
-    public function getDraftsByTypeAndOlderThenMonthsAgo(IntegrationType $type, int $months): Collection;
+    public function getDraftsByTypeAndBetweenMonthsOld(IntegrationType $type, int $startMonths, int $endMonths): Collection;
 }

--- a/tests/Console/Commands/SearchExpiredIntegrationsTest.php
+++ b/tests/Console/Commands/SearchExpiredIntegrationsTest.php
@@ -42,7 +42,7 @@ final class SearchExpiredIntegrationsTest extends TestCase
             'name' => 'Test',
             'description' => 'test',
             'status' => IntegrationStatus::Draft,
-            'created_at' => Carbon::now()->subYears(2),
+            'created_at' => Carbon::now()->subMonths(8),
             'reminder_email_sent' => null,
         ]);
         DB::table('contacts')->insert([

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -735,7 +735,10 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             ]);
         }
 
-        $this->assertCount($expectedCount, $this->integrationRepository->getDraftsByTypeAndOlderThenMonthsAgo(IntegrationType::SearchApi, 12));
+        $this->assertCount(
+            $expectedCount,
+            $this->integrationRepository->getDraftsByTypeAndBetweenMonthsOld(IntegrationType::SearchApi, 12, 24)
+        );
     }
 
     public static function dataProviderGetIntegrationsThatHaveNotBeenActivatedYet(): array
@@ -744,7 +747,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             'Should not be selected: wrong type' => [
                 IntegrationType::EntryApi,
                 IntegrationStatus::Draft,
-                Carbon::now()->subYears(2),
+                Carbon::now()->subMonths(14),
                 null,
                 true,
                 0,
@@ -752,7 +755,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             'Should not be selected: already active' => [
                 IntegrationType::SearchApi,
                 IntegrationStatus::Active,
-                Carbon::now()->subYears(2),
+                Carbon::now()->subMonths(14),
                 null,
                 true,
                 0,
@@ -760,7 +763,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             'Should not be selected: No contacts' => [
                 IntegrationType::SearchApi,
                 IntegrationStatus::Draft,
-                Carbon::now()->subYears(2),
+                Carbon::now()->subMonths(14),
                 null,
                 false,
                 0,
@@ -776,15 +779,23 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             'Should not be selected: Mail already sent' => [
                 IntegrationType::SearchApi,
                 IntegrationStatus::Draft,
-                Carbon::now()->subYears(2),
+                Carbon::now()->subMonths(14),
                 Carbon::now(),
                 true,
+                0,
+            ],
+            'Should not be selected: Too old' => [
+                IntegrationType::SearchApi,
+                IntegrationStatus::Draft,
+                Carbon::now()->subMonths(50),
+                Carbon::now(),
+                false,
                 0,
             ],
             'Should be selected!' => [
                 IntegrationType::SearchApi,
                 IntegrationStatus::Draft,
-                Carbon::now()->subYears(2),
+                Carbon::now()->subMonths(14),
                 null,
                 true,
                 1,


### PR DESCRIPTION
### Changed
In preparation for ticket https://jira.publiq.be/browse/PPF-605, we only want to sent the first reminder email for integrations younger then 1 year, to prevent sending 2 mails at the same time to an integrator.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-611