### PR TITLE
HOTFIX - cache is too agressive and caches only the ACC master realm key

### DIFF
--- a/app/Keycloak/TokenStrategy/ClientCredentials.php
+++ b/app/Keycloak/TokenStrategy/ClientCredentials.php
@@ -28,7 +28,7 @@ final class ClientCredentials implements TokenStrategy
 
     public function fetchToken(KeycloakHttpClient $client, Realm $realm): string
     {
-        $key = $realm->baseUrl . $realm->internalName . $realm->clientId;
+        $key = $realm->environment->value . $realm->internalName . $realm->clientId;
 
         if (isset($this->accessToken[$key])) {
             return $this->accessToken[$key];

--- a/app/Keycloak/TokenStrategy/ClientCredentials.php
+++ b/app/Keycloak/TokenStrategy/ClientCredentials.php
@@ -28,7 +28,7 @@ final class ClientCredentials implements TokenStrategy
 
     public function fetchToken(KeycloakHttpClient $client, Realm $realm): string
     {
-        $key = $realm->internalName . $realm->clientId;
+        $key = $realm->baseUrl . $realm->internalName . $realm->clientId;
 
         if (isset($this->accessToken[$key])) {
             return $this->accessToken[$key];


### PR DESCRIPTION
### Fixed
On test / prod Keycloak is broken because the cache for the token caches based on the realm name. But both test/acc/prod have a realm called "master", so it only cached the first, which was the acc env.

This fixes this by adding the url to the cache key.