### PR TITLE
BUGFIX When prod realm is missing migration script fails

### DIFF
--- a/app/Keycloak/Repositories/KeycloakClientRepository.php
+++ b/app/Keycloak/Repositories/KeycloakClientRepository.php
@@ -6,12 +6,16 @@ namespace App\Keycloak\Repositories;
 
 use App\Domain\Integrations\Environments;
 use App\Keycloak\Client;
+use App\Keycloak\Exception\RealmNotAvailable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Ramsey\Uuid\UuidInterface;
 
 interface KeycloakClientRepository
 {
+    /**
+     * @throws RealmNotAvailable
+     */
     public function create(Client ...$clients): void;
 
     /**


### PR DESCRIPTION
### Fixed
When the production realm of Keycloak is not configured, as is the case on the Test server, the migration script of auth0 -> keycloak would fail the very first time it would try to create a "prod" client.

I now catch this exception and just log it, it is oke that the test env does not have production clients.