### PR TITLE
PPF-56 Send mail when integration is approved

### DIFF
--- a/app/Domain/Integrations/Events/IntegrationApproved.php
+++ b/app/Domain/Integrations/Events/IntegrationApproved.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Integrations\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Ramsey\Uuid\UuidInterface;
+
+final class IntegrationApproved
+{
+    use Dispatchable;
+
+    public function __construct(public readonly UuidInterface $id)
+    {
+    }
+}

--- a/app/Domain/Integrations/Models/IntegrationModel.php
+++ b/app/Domain/Integrations/Models/IntegrationModel.php
@@ -11,6 +11,7 @@ use App\Domain\Coupons\Models\CouponModel;
 use App\Domain\Integrations\Environment;
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivationRequested;
+use App\Domain\Integrations\Events\IntegrationApproved;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationCreated;
 use App\Domain\Integrations\Events\IntegrationDeleted;
@@ -171,6 +172,7 @@ final class IntegrationModel extends UuidModel
         $this->update([
             'status' => IntegrationStatus::Active,
         ]);
+        IntegrationApproved::dispatch(Uuid::fromString($this->id));
     }
 
     public function block(): void

--- a/app/Domain/Mail/MailManager.php
+++ b/app/Domain/Mail/MailManager.php
@@ -9,6 +9,7 @@ use App\Domain\Contacts\ContactType;
 use App\Domain\Integrations\Events\ActivationExpired;
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivationRequested;
+use App\Domain\Integrations\Events\IntegrationApproved;
 use App\Domain\Integrations\Events\IntegrationCreatedWithContacts;
 use App\Domain\Integrations\Events\IntegrationDeleted;
 use App\Domain\Integrations\Integration;
@@ -45,6 +46,14 @@ final class MailManager
     {
         $integration = $this->integrationRepository->getById($event->id);
 
+        $this->sendMail($integration, $this->templates->getOrFail(TemplateName::INTEGRATION_ACTIVATED->value));
+    }
+
+    public function sendIntegrationApprovedMail(IntegrationApproved $event): void
+    {
+        $integration = $this->integrationRepository->getById($event->id);
+
+        // Currently the same e-mail as integration activated
         $this->sendMail($integration, $this->templates->getOrFail(TemplateName::INTEGRATION_ACTIVATED->value));
     }
 

--- a/app/Mails/MailServiceProvider.php
+++ b/app/Mails/MailServiceProvider.php
@@ -7,6 +7,7 @@ namespace App\Mails;
 use App\Domain\Integrations\Events\ActivationExpired;
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivationRequested;
+use App\Domain\Integrations\Events\IntegrationApproved;
 use App\Domain\Integrations\Events\IntegrationCreatedWithContacts;
 use App\Domain\Integrations\Events\IntegrationDeleted;
 use App\Domain\Integrations\Repositories\IntegrationMailRepository;
@@ -58,6 +59,7 @@ final class MailServiceProvider extends ServiceProvider
 
         Event::listen(IntegrationCreatedWithContacts::class, [MailManager::class, 'sendIntegrationCreatedMail']);
         Event::listen(IntegrationActivated::class, [MailManager::class, 'sendIntegrationActivatedMail']);
+        Event::listen(IntegrationApproved::class, [MailManager::class, 'sendIntegrationApprovedMail']);
         Event::listen(ActivationExpired::class, [MailManager::class, 'sendActivationReminderEmail']);
         Event::listen(IntegrationActivationRequested::class, [MailManager::class, 'sendIntegrationActivationRequestMail']);
         Event::listen(IntegrationDeleted::class, [MailManager::class, 'sendIntegrationDeletedMail']);

--- a/tests/Domain/Integrations/Models/IntegrationModelTest.php
+++ b/tests/Domain/Integrations/Models/IntegrationModelTest.php
@@ -6,6 +6,7 @@ namespace Tests\Domain\Integrations\Models;
 
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivationRequested;
+use App\Domain\Integrations\Events\IntegrationApproved;
 use App\Domain\Integrations\Events\IntegrationBlocked;
 use App\Domain\Integrations\Events\IntegrationUnblocked;
 use App\Domain\Integrations\IntegrationStatus;
@@ -89,6 +90,18 @@ final class IntegrationModelTest extends TestCase
         $this->integrationModel->activate();
 
         Event::assertDispatched(IntegrationActivated::class);
+
+        $this->assertDatabaseHas('integrations', [
+            'id' =>  $this->integrationModel->id,
+            'status' => IntegrationStatus::Active,
+        ]);
+    }
+
+    public function test_it_handles_approve(): void
+    {
+        $this->integrationModel->approve();
+
+        Event::assertDispatched(IntegrationApproved::class);
 
         $this->assertDatabaseHas('integrations', [
             'id' =>  $this->integrationModel->id,

--- a/tests/Domain/Mail/MailManagerTest.php
+++ b/tests/Domain/Mail/MailManagerTest.php
@@ -9,6 +9,7 @@ use App\Domain\Contacts\ContactType;
 use App\Domain\Integrations\Events\ActivationExpired;
 use App\Domain\Integrations\Events\IntegrationActivated;
 use App\Domain\Integrations\Events\IntegrationActivationRequested;
+use App\Domain\Integrations\Events\IntegrationApproved;
 use App\Domain\Integrations\Events\IntegrationCreatedWithContacts;
 use App\Domain\Integrations\Events\IntegrationDeleted;
 use App\Domain\Integrations\Integration;
@@ -196,6 +197,11 @@ final class MailManagerTest extends TestCase
             TemplateName::INTEGRATION_ACTIVATED->value => [
                 'event' => new IntegrationActivated(Uuid::fromString(self::INTEGRATION_ID)),
                 'method' => 'sendIntegrationActivatedMail',
+                'templateId' => self::TEMPLATE_ACTIVATED_ID,
+            ],
+            'integration_approved' => [
+                'event' => new IntegrationApproved(Uuid::fromString(self::INTEGRATION_ID)),
+                'method' => 'sendIntegrationApprovedMail',
                 'templateId' => self::TEMPLATE_ACTIVATED_ID,
             ],
             TemplateName::INTEGRATION_ACTIVATION_REQUEST->value => [


### PR DESCRIPTION
### Added
Previously we only sent a mail when an integration is activated, however entry-api goes trough an approval flow so it never gets "activated", it gets "approved".
The same mail is sent however in both cases.

I needed to add a new event to cover this use case.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-56 
