### PR TITLE
PPF-621 Change integrations mails to include all mails

### DIFF
--- a/app/Domain/Integrations/IntegrationMail.php
+++ b/app/Domain/Integrations/IntegrationMail.php
@@ -10,6 +10,7 @@ use Ramsey\Uuid\UuidInterface;
 final readonly class IntegrationMail
 {
     public function __construct(
+        public UuidInterface $uuid,
         public UuidInterface $integrationId,
         public TemplateName $templateName,
     ) {

--- a/app/Domain/Integrations/IntegrationMail.php
+++ b/app/Domain/Integrations/IntegrationMail.php
@@ -7,11 +7,11 @@ namespace App\Domain\Integrations;
 use App\Mails\Template\TemplateName;
 use Ramsey\Uuid\UuidInterface;
 
-final class IntegrationMail
+final readonly class IntegrationMail
 {
     public function __construct(
-        public readonly UuidInterface $integrationId,
-        public readonly TemplateName $templateName,
+        public UuidInterface $integrationId,
+        public TemplateName $templateName,
     ) {
     }
 }

--- a/app/Domain/Integrations/Models/IntegrationMailModel.php
+++ b/app/Domain/Integrations/Models/IntegrationMailModel.php
@@ -14,7 +14,6 @@ final class IntegrationMailModel extends Model
     protected $fillable = [
         'integration_id',
         'template_name',
-        'date',
     ];
 
     /**

--- a/app/Domain/Integrations/Models/IntegrationMailModel.php
+++ b/app/Domain/Integrations/Models/IntegrationMailModel.php
@@ -12,6 +12,7 @@ final class IntegrationMailModel extends Model
     protected $table = 'integrations_mails';
 
     protected $fillable = [
+        'uuid',
         'integration_id',
         'template_name',
     ];

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationMailRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationMailRepository.php
@@ -6,6 +6,7 @@ namespace App\Domain\Integrations\Repositories;
 
 use App\Domain\Integrations\IntegrationMail;
 use App\Domain\Integrations\Models\IntegrationMailModel;
+use Ramsey\Uuid\Uuid;
 
 final class EloquentIntegrationMailRepository implements IntegrationMailRepository
 {
@@ -13,6 +14,7 @@ final class EloquentIntegrationMailRepository implements IntegrationMailReposito
     {
         IntegrationMailModel::query()->create(
             [
+                'uuid' => $integrationMail->uuid,
                 'integration_id' => $integrationMail->integrationId->toString(),
                 'template_name' => $integrationMail->templateName,
             ]

--- a/app/Domain/Integrations/Repositories/EloquentIntegrationMailRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentIntegrationMailRepository.php
@@ -6,7 +6,6 @@ namespace App\Domain\Integrations\Repositories;
 
 use App\Domain\Integrations\IntegrationMail;
 use App\Domain\Integrations\Models\IntegrationMailModel;
-use Ramsey\Uuid\Uuid;
 
 final class EloquentIntegrationMailRepository implements IntegrationMailRepository
 {

--- a/app/Domain/Mail/MailManager.php
+++ b/app/Domain/Mail/MailManager.php
@@ -132,7 +132,7 @@ final class MailManager
         $this->integrationMailRepository->create(new IntegrationMail(
             Uuid::uuid4(),
             $integration->id,
-            $template->type,
+            $template->name,
         ));
     }
 }

--- a/app/Domain/Mail/MailManager.php
+++ b/app/Domain/Mail/MailManager.php
@@ -76,11 +76,6 @@ final class MailManager
         $integration = $this->integrationRepository->getById($event->id);
 
         $this->sendMail($integration, $this->templates->getOrFail($event->templateName->value));
-
-        $this->integrationMailRepository->create(new IntegrationMail(
-            $event->id,
-            $event->templateName,
-        ));
     }
 
     private function getFrom(): Address
@@ -132,5 +127,10 @@ final class MailManager
                 $this->getIntegrationVariables($contact, $integration)
             );
         }
+
+        $this->integrationMailRepository->create(new IntegrationMail(
+            $integration->id,
+            $template->type,
+        ));
     }
 }

--- a/app/Domain/Mail/MailManager.php
+++ b/app/Domain/Mail/MailManager.php
@@ -20,6 +20,7 @@ use App\Mails\Template\Template;
 use App\Mails\Template\TemplateName;
 use App\Mails\Template\Templates;
 use Illuminate\Bus\Queueable;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Mime\Address;
 
 final class MailManager
@@ -129,6 +130,7 @@ final class MailManager
         }
 
         $this->integrationMailRepository->create(new IntegrationMail(
+            Uuid::uuid4(),
             $integration->id,
             $template->type,
         ));

--- a/app/Mails/Template/Template.php
+++ b/app/Mails/Template/Template.php
@@ -9,7 +9,7 @@ final class Template
     public function __construct(
         public TemplateName $type,
         public int $id,
-        public bool $enabled,
+        public bool $enabled = true,
     ) {
     }
 }

--- a/app/Mails/Template/Template.php
+++ b/app/Mails/Template/Template.php
@@ -7,7 +7,7 @@ namespace App\Mails\Template;
 final class Template
 {
     public function __construct(
-        public string $type,
+        public TemplateName $type,
         public int $id,
         public bool $enabled,
     ) {

--- a/app/Mails/Template/Template.php
+++ b/app/Mails/Template/Template.php
@@ -7,7 +7,7 @@ namespace App\Mails\Template;
 final class Template
 {
     public function __construct(
-        public TemplateName $type,
+        public TemplateName $name,
         public int $id,
         public bool $enabled = true,
     ) {

--- a/app/Mails/Template/Templates.php
+++ b/app/Mails/Template/Templates.php
@@ -17,7 +17,7 @@ final class Templates extends Collection
         $collection = new self();
 
         foreach ($templates as $type => $template) {
-            $collection->put($type, new Template($type, (int)$template['id'], $template['enabled']));
+            $collection->put($type, new Template(TemplateName::from($type), (int)$template['id'], $template['enabled']));
         }
 
         return $collection;

--- a/database/migrations/2024_10_07_144133_add_uuid_to_integrations_mails_table.php
+++ b/database/migrations/2024_10_07_144133_add_uuid_to_integrations_mails_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Ramsey\Uuid\Uuid;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('integrations_mails', function (Blueprint $table) {
+            // Add the UUID field (but don't set it as primary key yet)
+            $table->uuid('uuid')->nullable()->first();
+        });
+
+        // Autofill UUIDs for existing records to prevent null errors later
+        DB::table('integrations_mails')->update(['uuid' => Uuid::uuid4()->toString()]);
+
+        // Finish the migration, drop existing primary key and make the UUID field non-nullable and set it as the primary key
+        Schema::table('integrations_mails', function (Blueprint $table) {
+            $table->dropPrimary(['integration_id', 'template_name']);
+            $table->uuid('uuid')->primary()->change();
+
+            $table->index(['integration_id', 'template_name'], 'integration_id_template_name_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('integrations_mails', function (Blueprint $table) {
+            $table->dropPrimary(['uuid']);
+
+            $table->dropIndex('integration_id_template_name_index');
+
+            $table->primary(['integration_id', 'template_name']);
+
+            $table->dropColumn('uuid');
+        });
+    }
+};

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationMailRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationMailRepositoryTest.php
@@ -18,6 +18,7 @@ final class EloquentIntegrationMailRepositoryTest extends TestCase
         $repository = new EloquentIntegrationMailRepository();
 
         $id = Uuid::uuid4();
+        $integrationId = Uuid::uuid4();
         $templateName = TemplateName::INTEGRATION_ACTIVATION_REMINDER;
 
         $now = Carbon::now();
@@ -25,11 +26,13 @@ final class EloquentIntegrationMailRepositoryTest extends TestCase
 
         $repository->create(new IntegrationMail(
             $id,
+            $integrationId,
             $templateName,
         ));
 
         $this->assertDatabaseHas('integrations_mails', [
-            'integration_id' => $id,
+            'uuid' => $id,
+            'integration_id' => $integrationId,
             'template_name' => $templateName,
             'created_at' => $now,
         ]);

--- a/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
+++ b/tests/Domain/Integrations/Repositories/EloquentIntegrationRepositoryTest.php
@@ -709,7 +709,7 @@ final class EloquentIntegrationRepositoryTest extends TestCase
         IntegrationType $integrationType,
         IntegrationStatus $status,
         Carbon $date,
-        ?Carbon $reminderEmailSent,
+        ?Carbon $mailAlreadySent,
         bool $hasContact,
         TemplateName $templateName,
         int $expectedCount,
@@ -725,8 +725,9 @@ final class EloquentIntegrationRepositoryTest extends TestCase
             'created_at' => $date,
         ]);
 
-        if ($reminderEmailSent !== null) {
+        if ($mailAlreadySent) {
             DB::table('integrations_mails')->insert([
+                'uuid' => Uuid::uuid4()->toString(),
                 'integration_id' => $integrationId,
                 'template_name' => TemplateName::INTEGRATION_ACTIVATION_REMINDER->value,
             ]);

--- a/tests/Domain/Mail/MailManagerTest.php
+++ b/tests/Domain/Mail/MailManagerTest.php
@@ -234,32 +234,26 @@ final class MailManagerTest extends TestCase
             TemplateName::INTEGRATION_CREATED->value => [
                 'id' => self::TEMPLATE_CREATED_ID,
                 'enabled' => true,
-                'subject' => 'Welcome to Publiq platform - Let\'s get you started!',
             ],
             TemplateName::INTEGRATION_ACTIVATED->value => [
                 'id' => self::TEMPLATE_ACTIVATED_ID,
                 'enabled' => true,
-                'subject' => 'Publiq platform - Integration activated',
             ],
             TemplateName::INTEGRATION_ACTIVATION_REMINDER->value => [
                 'id' => self::TEMPLATE_INTEGRATION_ACTIVATION_REMINDER,
                 'enabled' => true,
-                'subject' => 'Publiq platform - Can we help you to activate your integration?',
             ],
             TemplateName::INTEGRATION_FINAL_ACTIVATION_REMINDER->value => [
                 'id' => self::TEMPLATE_INTEGRATION_FINAL_ACTIVATION_REMINDER,
                 'enabled' => true,
-                'subject' => 'Publiq platform - Can we help you to activate your integration?',
             ],
             TemplateName::INTEGRATION_ACTIVATION_REQUEST->value => [
                 'id' => self::TEMPLATE_ACTIVATION_REQUESTED_ID,
                 'enabled' => true,
-                'subject' => 'Publiq platform - Request for activating integration',
             ],
             TemplateName::INTEGRATION_DELETED->value => [
                 'id' => self::TEMPLATE_DELETED_ID,
                 'enabled' => true,
-                'subject' => 'Publiq platform - Integration deleted',
             ],
         ];
     }

--- a/tests/Domain/Mail/MailManagerTest.php
+++ b/tests/Domain/Mail/MailManagerTest.php
@@ -173,7 +173,7 @@ final class MailManagerTest extends TestCase
             ->expects($this->once())
             ->method('create')
             ->with($this->callback(function (IntegrationMail $integrationMail) use ($template) {
-                return $integrationMail->templateName === $template->type &&
+                return $integrationMail->templateName === $template->name &&
                     $integrationMail->integrationId->toString() === self::INTEGRATION_ID;
             }));
 

--- a/tests/Domain/Mail/MailManagerTest.php
+++ b/tests/Domain/Mail/MailManagerTest.php
@@ -172,10 +172,10 @@ final class MailManagerTest extends TestCase
         $this->integrationMailRepository
             ->expects($this->once())
             ->method('create')
-            ->with(new IntegrationMail(
-                Uuid::fromString(self::INTEGRATION_ID),
-                $template->type,
-            ));
+            ->with($this->callback(function (IntegrationMail $integrationMail) use ($template) {
+                return $integrationMail->templateName === $template->type &&
+                    $integrationMail->integrationId->toString() === self::INTEGRATION_ID;
+            }));
 
         $this->mailManager->$method($event);
     }


### PR DESCRIPTION
Currently only the mail for reminder and final reminder are inserted in the integrations_mails table.

For future logging purposes it would be useful if all transactional emails where logged in this table.

### Changed
- Add random id column to table, make this the primary key.
- Add an index on (integration_id, template_name)
- Add entry into the table integrations_mails for all transactional emails in their handlers.

### Removed
Some minor boy scouting changes
- Remove "date" from IntegrationMailRepository (this field was forgotten to be removed)
- Remove "Subject" from tests because subjects are now configured in Mailjet (was in previous pr)

---
Ticket: https://jira.uitdatabank.be/browse/PPF-621
