### PR TITLE
Fixed blank UI for integrations with no keycloak client

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,7 +37,7 @@ final class HandleInertiaRequests extends Middleware
                 ],
                 'keycloak' => [
                     'enabled' => config('keycloak.enabled'),
-                    'testClientEnabled' => config('keycloak.testClientEnabled'),
+                    'creationEnabled' => config('keycloak.creationEnabled'),
                 ],
             ],
             'widgetConfig' => [

--- a/resources/ts/Components/IntegrationClientCredential.tsx
+++ b/resources/ts/Components/IntegrationClientCredential.tsx
@@ -49,7 +49,8 @@ export const IntegrationClientCredentials = ({
   const { config } = usePageProps();
 
   const clientWithLabels =
-    config.keycloak.enabled || (!isLive && config.keycloak.testClientEnabled)
+    config.keycloak.enabled ||
+    (!isLive && config.keycloak.testClientEnabled && keycloakClient)
       ? [
           {
             label: "details.credentials.client_id",

--- a/resources/ts/Components/IntegrationClientCredential.tsx
+++ b/resources/ts/Components/IntegrationClientCredential.tsx
@@ -6,6 +6,7 @@ import { IntegrationStatus } from "../types/IntegrationStatus";
 import { Alert } from "./Alert";
 import type { Integration } from "../types/Integration";
 import type { AuthClient, KeycloakClient } from "../types/Credentials";
+import { usePageProps } from "../hooks/usePageProps";
 
 type Props = {
   client: {
@@ -45,8 +46,10 @@ export const IntegrationClientCredentials = ({
   isLive: boolean;
 }) => {
   const { t } = useTranslation();
+  const { config } = usePageProps();
 
-  const clientToShow = keycloakClient && !isLive ? keycloakClient : client;
+  const clientToShow =
+    config.keycloak.creationEnabled && keycloakClient ? keycloakClient : client;
   const clientWithLabels = [
     {
       label: "details.credentials.client_id",

--- a/resources/ts/Components/IntegrationClientCredential.tsx
+++ b/resources/ts/Components/IntegrationClientCredential.tsx
@@ -5,7 +5,6 @@ import { IntegrationType } from "../types/IntegrationType";
 import { IntegrationStatus } from "../types/IntegrationStatus";
 import { Alert } from "./Alert";
 import type { Integration } from "../types/Integration";
-import { usePageProps } from "../hooks/usePageProps";
 import type { AuthClient, KeycloakClient } from "../types/Credentials";
 
 type Props = {

--- a/resources/ts/Components/IntegrationClientCredential.tsx
+++ b/resources/ts/Components/IntegrationClientCredential.tsx
@@ -46,31 +46,18 @@ export const IntegrationClientCredentials = ({
   isLive: boolean;
 }) => {
   const { t } = useTranslation();
-  const { config } = usePageProps();
 
-  const clientWithLabels =
-    config.keycloak.enabled ||
-    (!isLive && config.keycloak.testClientEnabled && keycloakClient)
-      ? [
-          {
-            label: "details.credentials.client_id",
-            value: keycloakClient?.clientId,
-          },
-          {
-            label: "details.credentials.client_secret",
-            value: keycloakClient?.clientSecret,
-          },
-        ]
-      : [
-          {
-            label: "details.credentials.client_id",
-            value: client?.clientId,
-          },
-          {
-            label: "details.credentials.client_secret",
-            value: client?.clientSecret,
-          },
-        ];
+  const clientToShow = keycloakClient && !isLive ? keycloakClient : client;
+  const clientWithLabels = [
+    {
+      label: "details.credentials.client_id",
+      value: clientToShow?.clientId,
+    },
+    {
+      label: "details.credentials.client_secret",
+      value: clientToShow?.clientSecret,
+    },
+  ];
 
   return (
     <>

--- a/resources/ts/types/PageProps.ts
+++ b/resources/ts/types/PageProps.ts
@@ -13,7 +13,7 @@ type Config = {
   };
   keycloak: {
     enabled: boolean;
-    testClientEnabled: boolean;
+    creationEnabled: boolean;
   };
 };
 


### PR DESCRIPTION
### Fixed
- Fixed blank UI for integrations with no keycloak client

---

@simon-debruijn @grubolsch Some integrations do not yet have a Keycloak client to show, even if the related env variables are enabled. As it is my understanding that this is an "unhappy path" state, and that otherwise we should always have one to show, I've tried to simplify the logic to trust the data first and foremost in the meantime, so that users aren't too confused. But since the previous condition relied on `KEYCLOAK_TEST_CLIENT_ENABLED` – which from my understanding is a temporary thing – I'm a bit unsure what the actual real condition should be if that's not enough. Especially the isLive part. So all that to say I tried to trust the data in place but perhaps it's shortsighted.

---
Ticket: https://jira.publiq.be/browse/PPF-624