### PR TITLE
Hotfix UiTID Widget

### DIFF
--- a/resources/ts/Components/UitIdWidget.tsx
+++ b/resources/ts/Components/UitIdWidget.tsx
@@ -29,7 +29,7 @@ export const UitIdWidget = ({
         uitidProfileUrl: profileUrl,
         uitidRegisterUrl: registerUrl,
         defaultLanguage: "nl",
-        oAuthDomain: oAuthDomain,
+        auth0Domain: oAuthDomain,
         loginUrl: "/login",
         logoutUrl: "/logout",
         accessTokenCookieName: "",


### PR DESCRIPTION
### Changed

- revert `oAuthDomain` back to `auth0Domain`, because external library still uses it.

### Fixed

- The top `UiTID Widget` bar is show again

---