### PR TITLE
Hotfix Laravel Nova routes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "inertiajs/inertia-laravel": "^2.0.0",
         "laravel/framework": "^v11.22.0",
         "laravel/horizon": "^5.10",
-        "laravel/nova": "^5.0",
+        "laravel/nova": "5.0.4",
         "laravel/tinker": "^2.7",
         "mailjet/mailjet-apiv3-php": "^1.6",
         "publiq/insightly-link": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e7e47e5ffb4d65601a686beb9754327",
+    "content-hash": "6347ed53b273c6fc0637f3f3572c167b",
     "packages": [
         {
             "name": "Publiq/insightly-link",
@@ -2499,17 +2499,17 @@
         },
         {
             "name": "laravel/nova",
-            "version": "5.1.3",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "git@github.com:laravel/nova.git",
-                "reference": "0561ac87e508e8a4205c4daf31bc71fbb06e6513"
+                "reference": "fb3de5987c32768f5e055e1b9767d64b8bcc0705"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://nova.laravel.com/dist/laravel/nova/laravel-nova-0561ac87e508e8a4205c4daf31bc71fbb06e6513-zip-dec022.zip",
-                "reference": "0561ac87e508e8a4205c4daf31bc71fbb06e6513",
-                "shasum": "3568ea385447c8934f934d2afd0694a1c14c665b"
+                "url": "https://nova.laravel.com/dist/laravel/nova/laravel-nova-fb3de5987c32768f5e055e1b9767d64b8bcc0705-zip-3b75c2.zip",
+                "reference": "fb3de5987c32768f5e055e1b9767d64b8bcc0705",
+                "shasum": "4540184bb4d292c08d679790bb2babb54d2d4efe"
             },
             "require": {
                 "brick/money": "^0.8|^0.9|^0.10",
@@ -2522,7 +2522,6 @@
                 "rap2hpoutre/fast-excel": "^5.4",
                 "spatie/once": "^3.0",
                 "symfony/console": "^6.4.14|^7.0.3",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/finder": "^6.4.13|^7.0.3",
                 "symfony/polyfill-intl-icu": "^1.31",
                 "symfony/polyfill-php83": "^1.31",
@@ -2547,9 +2546,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "5.x-dev"
-                },
                 "laravel": {
                     "providers": [
                         "Laravel\\Nova\\NovaCoreServiceProvider"
@@ -2663,9 +2659,9 @@
                 "laravel"
             ],
             "support": {
-                "source": "https://github.com/laravel/nova/tree/v5.1.3"
+                "source": "https://github.com/laravel/nova/tree/v5.0.4"
             },
-            "time": "2025-01-12T13:36:26+00:00"
+            "time": "2024-12-19T14:56:23+00:00"
         },
         {
             "name": "laravel/prompts",


### PR DESCRIPTION
### Fixed
- Revert to Laravel Nova 5.0.4 to fix Laravel Nova routes
