### PR TITLE
Hotfix to register Laravel Nova routes

### DIFF
--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -59,6 +59,7 @@ final class NovaServiceProvider extends NovaApplicationServiceProvider
 
     public function register(): void
     {
+        parent::register();
         Nova::initialPath('/resources/' . Integration::uriKey());
     }
 }


### PR DESCRIPTION
### Fixed
- Register Nova routes after upgrade to Laravel Nova 5
