### PR TITLE
Don't just log but also capture Keycloak exceptions during client creation

### DIFF
--- a/app/Keycloak/Jobs/BlockClientHandler.php
+++ b/app/Keycloak/Jobs/BlockClientHandler.php
@@ -32,6 +32,7 @@ final readonly class BlockClientHandler implements ShouldQueue
                 [
                     'domain' => 'keycloak',
                     'id' => $event->id,
+                    'exception' => $e,
                 ]
             );
             return;

--- a/app/Keycloak/Jobs/UnblockClientHandler.php
+++ b/app/Keycloak/Jobs/UnblockClientHandler.php
@@ -32,6 +32,7 @@ final readonly class UnblockClientHandler implements ShouldQueue
                 [
                     'domain' => 'keycloak',
                     'id' => $event->id,
+                    'exception' => $e,
                 ]
             );
             return;

--- a/app/Keycloak/Listeners/CreateClients.php
+++ b/app/Keycloak/Listeners/CreateClients.php
@@ -19,6 +19,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use function Sentry\captureException;
 
 final class CreateClients implements ShouldQueue
 {
@@ -88,6 +89,7 @@ final class CreateClients implements ShouldQueue
 
                 $clientCollection->add($client);
             } catch (KeyCloakApiFailed $e) {
+                captureException($e);
                 $this->logger->error($e->getMessage());
             }
         }

--- a/app/Keycloak/Listeners/CreateClients.php
+++ b/app/Keycloak/Listeners/CreateClients.php
@@ -19,6 +19,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
 use Throwable;
+
 use function Sentry\captureException;
 
 final class CreateClients implements ShouldQueue

--- a/app/Keycloak/Listeners/CreateClients.php
+++ b/app/Keycloak/Listeners/CreateClients.php
@@ -20,8 +20,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
-use function Sentry\captureException;
-
 final class CreateClients implements ShouldQueue
 {
     use Queueable;

--- a/app/Keycloak/Listeners/CreateClients.php
+++ b/app/Keycloak/Listeners/CreateClients.php
@@ -90,8 +90,7 @@ final class CreateClients implements ShouldQueue
 
                 $clientCollection->add($client);
             } catch (KeyCloakApiFailed $e) {
-                captureException($e);
-                $this->logger->error($e->getMessage());
+                $this->logger->error($e->getMessage(), ['exception' => $e]);
             }
         }
 

--- a/app/UiTiDv1/Jobs/BlockConsumerHandler.php
+++ b/app/UiTiDv1/Jobs/BlockConsumerHandler.php
@@ -39,6 +39,7 @@ final class BlockConsumerHandler implements ShouldQueue
                 [
                     'domain' => 'uitid',
                     'id' => $event->id,
+                    'exception' => $e,
                 ]
             );
             return;

--- a/app/UiTiDv1/Jobs/UnblockConsumerHandler.php
+++ b/app/UiTiDv1/Jobs/UnblockConsumerHandler.php
@@ -39,6 +39,7 @@ final class UnblockConsumerHandler implements ShouldQueue
                 [
                     'domain' => 'uitid',
                     'id' => $event->id,
+                    'exception' => $e,
                 ]
             );
             return;


### PR DESCRIPTION
### Fixed
- Don't just log but also capture Keycloak exceptions during client creation

---

We seem to be throwing the Exception with the entire response from the API, so I don't think there is that much additional information to log that could help with the error in the screenshot since it seems Keycloak really is just returning "401 Unauthorized" without elaboration. 

So this change should at least prevent Keycloak exceptions from not reaching Sentry, as currently they are caught and logged but not released back for capture by Sentry? This will hopefully provide us with a lot more metadata to understand what goes wrong.

Ticket: https://jira.publiq.be/browse/PPF-659
