### PR TITLE
PPF-655 Add 2FA for admins

### DIFF
--- a/app/Domain/Auth/Controllers/CallbackController.php
+++ b/app/Domain/Auth/Controllers/CallbackController.php
@@ -34,7 +34,7 @@ final class CallbackController
 
                     $url = $auth0->login(null, $this->addAcrEnforcementParam());
 
-                    return redirect()->intended($url);
+                    return redirect()->to($url);
                 }
             }
 

--- a/app/Domain/Auth/Controllers/CallbackController.php
+++ b/app/Domain/Auth/Controllers/CallbackController.php
@@ -12,8 +12,13 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 
-final class CallbackController
+final readonly class CallbackController
 {
+    /** @param array<string> $loginParams */
+    public function __construct(private array $loginParams)
+    {
+    }
+
     public function __invoke(Request $request): RedirectResponse
     {
         /** @var Auth0 $auth0 */
@@ -46,10 +51,9 @@ final class CallbackController
         return redirect()->intended('/');
     }
 
-    public function addAcrEnforcementParam(): array
+    private function addAcrEnforcementParam(): array
     {
-        $params = [];
-        parse_str(config(KeycloakConfig::KEYCLOAK_LOGIN_PARAMETERS), $params);
+        $params = $this->loginParams;
         $params['acr_values'] = 'highest';
         unset($params['prompt']);
         return $params;

--- a/app/Keycloak/KeycloakConfig.php
+++ b/app/Keycloak/KeycloakConfig.php
@@ -12,4 +12,5 @@ final class KeycloakConfig
     public const KEYCLOAK_CLIENT_ID = 'keycloak.login.clientId';
     public const KEYCLOAK_REALM_NAME = 'keycloak.login.realmName';
     public const KEYCLOAK_LOGIN_PARAMETERS = 'keycloak.login.parameters';
+    public const KEYCLOAK_ENFORCE_2FA_FOR_ADMINS = 'keycloak.login.enforce2FAForAdmins';
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Domain\Activity\Policies\ActivityPolicy;
+use App\Domain\Auth\Controllers\CallbackController;
 use App\Domain\Auth\Controllers\LoginController;
 use App\Domain\Auth\UserProvider;
 use App\Domain\Contacts\Models\ContactModel;
@@ -73,6 +74,10 @@ final class AuthServiceProvider extends ServiceProvider
         parse_str(config(KeycloakConfig::KEYCLOAK_LOGIN_PARAMETERS), $oAuthLoginParameters);
 
         $this->app->when(LoginController::class)
+            ->needs('$loginParams')
+            ->give($oAuthLoginParameters);
+
+        $this->app->when(CallbackController::class)
             ->needs('$loginParams')
             ->give($oAuthLoginParameters);
     }

--- a/config/keycloak.php
+++ b/config/keycloak.php
@@ -10,6 +10,7 @@ return [
     'testClientEnabled' => env('KEYCLOAK_TEST_CLIENT_ENABLED', false),
     'login' => [
         'strategy' => SdkConfiguration::STRATEGY_REGULAR,
+        'enforce2FAForAdmins' => env('KEYCLOAK_ENFORCE_2FA_FOR_ADMINS', false),
         'domain' => env('KEYCLOAK_LOGIN_DOMAIN'),
         'managementDomain' => env('KEYCLOAK_LOGIN_MANAGEMENT_DOMAIN'),
         'clientId' => env('KEYCLOAK_LOGIN_CLIENT_ID'),

--- a/tests/Domain/Auth/Controllers/CallbackControllerTest.php
+++ b/tests/Domain/Auth/Controllers/CallbackControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Auth\Controllers;
+
+use App\Domain\Auth\Controllers\CallbackController;
+use App\Keycloak\KeycloakConfig;
+use Auth0\SDK\Auth0;
+use Auth0\SDK\Contract\Auth0Interface;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+final class CallbackControllerTest extends TestCase
+{
+    private string $loginUrl;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('nova.users', ['admin@publiq.be']);
+        Config::set(KeycloakConfig::KEYCLOAK_LOGIN_PARAMETERS, 'clientId=123&prompt=login');
+        Config::set(KeycloakConfig::KEYCLOAK_ENFORCE_2FA_FOR_ADMINS, true);
+
+        Config::set('session.driver', 'null');//set driver to NULL instead of mocking
+
+        $this->loginUrl = 'https://acc.keycloak.publiq.com/login';
+    }
+
+    public function test_redirects_to_acr_highest_login_if_user_known_but_not_highest_acr(): void
+    {
+        $auth0 = $this->createMock(Auth0Interface::class);
+        $auth0->method('exchange')->willReturn(true);
+        $auth0->method('getUser')->willReturn([
+            'email' => 'admin@publiq.be',
+            'acr' => 'standard',
+        ]);
+        $auth0->expects($this->once())->method('clear');
+        $auth0->method('login')->willReturn($this->loginUrl);
+        app()->instance(Auth0::class, $auth0);
+
+        $redirect = $this->createMock(Redirector::class);
+        $redirect->expects($this->once())->method('intended')->with($this->loginUrl)->willReturn(new RedirectResponse($this->loginUrl));
+        app()->instance('redirect', $redirect);
+
+        $controller = new CallbackController();
+        $request = Request::create('/auth/callback', 'GET');
+
+        $response = $controller($request);
+
+        $this->assertEquals($this->loginUrl, $response->getTargetUrl());
+    }
+
+    public function test_logs_in_user_with_highest_acr_and_redirects_home(): void
+    {
+        $mockUser = [
+            'email' => 'admin@publiq.be',
+            'acr' => 'highest',
+        ];
+
+        $auth0 = $this->createMock(Auth0Interface::class);
+        $auth0->method('exchange')->willReturn(true);
+        $auth0->method('getUser')->willReturn($mockUser);
+        $auth0->method('getIdToken')->willReturn('mock-id-token');
+
+        app()->instance(Auth0::class, $auth0);
+
+        Auth::shouldReceive('login')->once();
+
+        Config::set('nova.users', []);
+
+        $controller = new CallbackController();
+        $request = Request::create('/auth/callback', 'GET');
+
+        $redirect = $this->createMock(Redirector::class);
+        $redirect->expects($this->once())->method('intended')->with('/')->willReturn(new RedirectResponse('/'));
+        app()->instance('redirect', $redirect);
+
+        $response = $controller($request);
+
+        $this->assertEquals('/', $response->getTargetUrl());
+    }
+
+    public function test_user_not_in_nova_users_gets_logged_in(): void
+    {
+        $mockUser = [
+            'email' => 'unknown@example.com',
+            'acr' => 'lowest',
+        ];
+
+        $auth0 = $this->createMock(Auth0Interface::class);
+        $auth0->method('exchange')->willReturn(true);
+        $auth0->method('getUser')->willReturn($mockUser);
+        $auth0->method('getIdToken')->willReturn('mock-id-token');
+
+        Auth::shouldReceive('login')->once();
+
+        app()->instance(Auth0::class, $auth0);
+
+        $redirect = $this->createMock(Redirector::class);
+        $redirect->expects($this->once())->method('intended')->with('/')->willReturn(new RedirectResponse('/'));
+        app()->instance('redirect', $redirect);
+
+        $controller = new CallbackController();
+        $request = Request::create('/auth/callback', 'GET');
+        $response = $controller($request);
+
+        $this->assertEquals('/', $response->getTargetUrl());
+    }
+
+    public function test_redirects_home_if_exchange_fails(): void
+    {
+        $auth0 = $this->createMock(Auth0Interface::class);
+        $auth0->method('exchange')->willReturn(false);
+        app()->instance(Auth0::class, $auth0);
+
+        $redirect = $this->createMock(Redirector::class);
+        $redirect->expects($this->once())->method('intended')->with('/')->willReturn(new RedirectResponse('/'));
+        app()->instance('redirect', $redirect);
+
+        $controller = new CallbackController();
+        $request = Request::create('/auth/callback', 'GET');
+
+        $response = $controller($request);
+
+        $this->assertEquals('/', $response->getTargetUrl());
+    }
+}

--- a/tests/Domain/Auth/Controllers/CallbackControllerTest.php
+++ b/tests/Domain/Auth/Controllers/CallbackControllerTest.php
@@ -45,7 +45,7 @@ final class CallbackControllerTest extends TestCase
         app()->instance(Auth0::class, $auth0);
 
         $redirect = $this->createMock(Redirector::class);
-        $redirect->expects($this->once())->method('intended')->with($this->loginUrl)->willReturn(new RedirectResponse($this->loginUrl));
+        $redirect->expects($this->once())->method('to')->with($this->loginUrl)->willReturn(new RedirectResponse($this->loginUrl));
         app()->instance('redirect', $redirect);
 
         $controller = new CallbackController();


### PR DESCRIPTION
### Added
- This PR introduces 2FA for admin users (defined in nova_users.php config).
It leverages elevated authentication to enforce this behavior.
- This feature is protected by a feature flag (KEYCLOAK_ENFORCE_2FA_FOR_ADMINS) to allow a staggered rollout to acc/test/prod.

### How it works
All users authenticate normally via Keycloak.
On callback, we check the ACR level (acr) returned by Keycloak.
If the user is in nova_users.php but doesn't have the highest ACR, we trigger a re-login with acr_values=highest to enforce 2FA (OTP).
Once authenticated at the required level, the user is logged in as usual.

### Related config pr
https://github.com/cultuurnet/appconfig/pull/1005

---
Ticket: https://jira.uitdatabank.be/browse/PPF-655
