### PR TITLE
Do not allow everybody on admin panel on dev

### DIFF
--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -34,6 +34,13 @@ final class NovaServiceProvider extends NovaApplicationServiceProvider
                 ->register();
     }
 
+    protected function authorization(): void
+    {
+        Nova::auth(static function ($request) {
+            return Gate::check('viewNova', [Nova::user($request)]);
+        });
+    }
+
     protected function gate(): void
     {
         Gate::define(


### PR DESCRIPTION
### Changed

 - `NovaServiceProvider`: override `authorization()` to not allow everybody on localhost.

### Fixed

- The `local`-environment mimicks more closely the `server`-environments

---