### PR TITLE
[minor] fix invalid prop id error

### DIFF
--- a/resources/ts/Components/Integrations/Detail/OrganizersDatalist.tsx
+++ b/resources/ts/Components/Integrations/Detail/OrganizersDatalist.tsx
@@ -119,7 +119,7 @@ export const OrganizersDatalist = ({ onChange, value, ...props }: Props) => {
         className="w-full relative"
         {...props}
         component={
-          <>
+          <div>
             <Input
               type="text"
               name="organizers"
@@ -143,7 +143,7 @@ export const OrganizersDatalist = ({ onChange, value, ...props }: Props) => {
                   ))}
                 </ul>
               )}
-          </>
+          </div>
         }
       />
     </>


### PR DESCRIPTION
### Fixed
- Got the error "OrganizersDatalist.tsx:122 Invalid prop id supplied to React.Fragment. React.Fragment can only have key and children props." in the console.

If I understand correctly, I am getting this error because the code uses a "Fragment" a component FormElement, and that component is trying to pass extra props like id internally. However, a fragment can only have key and children as props, which is why it fails. Do I understand correctly?
But I might miss nuance in this approach, so please verify.
