### PR TITLE
PPF-693 Cleanup permissions when revoking organizer

### DIFF
--- a/app/Domain/Integrations/Repositories/EloquentUdbOrganizerRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentUdbOrganizerRepository.php
@@ -23,6 +23,10 @@ final class EloquentUdbOrganizerRepository implements UdbOrganizerRepository
             'organizer_id' => $organizer->organizerId->toString(),
             'status' => $organizer->status->value,
         ]);
+
+        if ($organizer->status === UdbOrganizerStatus::Approved) {
+            UdbOrganizerApproved::dispatch($organizer->organizerId, $organizer->integrationId);
+        }
     }
 
     public function createInBulk(UdbOrganizers $organizers): void

--- a/app/Domain/Integrations/Repositories/EloquentUdbOrganizerRepository.php
+++ b/app/Domain/Integrations/Repositories/EloquentUdbOrganizerRepository.php
@@ -40,12 +40,13 @@ final class EloquentUdbOrganizerRepository implements UdbOrganizerRepository
 
     public function updateStatus(UdbOrganizer $organizer, UdbOrganizerStatus $newStatus): void
     {
-        UdbOrganizerModel::query()->update(
-            [
-                'id' => $organizer->id->toString(),
+        UdbOrganizerModel::query()
+            ->where('id', $organizer->id->toString())
+            ->update(
+                [
                 'status' => $newStatus->value,
             ]
-        );
+            );
 
         if ($newStatus === UdbOrganizerStatus::Approved) {
             UdbOrganizerApproved::dispatch($organizer->organizerId, $organizer->integrationId);

--- a/app/Mails/MailServiceProvider.php
+++ b/app/Mails/MailServiceProvider.php
@@ -29,6 +29,10 @@ final class MailServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->app->singleton(MailTemplateResolver::class, function () {
+            return $this->app->get(BladeMailTemplateResolver::class);
+        });
+
         if (!config(MailjetConfig::TRANSACTIONAL_EMAILS_ENABLED)) {
             return;
         }
@@ -57,10 +61,6 @@ final class MailServiceProvider extends ServiceProvider
                 Templates::build(config(MailjetConfig::MAILJET_TEMPLATES)),
                 config('app.url'),
             );
-        });
-
-        $this->app->singleton(MailTemplateResolver::class, function () {
-            return $this->app->get(BladeMailTemplateResolver::class);
         });
 
         Event::listen(IntegrationCreatedWithContacts::class, [MailManager::class, 'sendIntegrationCreatedMail']);

--- a/app/Nova/Actions/UdbOrganizer/RequestUdbOrganizer.php
+++ b/app/Nova/Actions/UdbOrganizer/RequestUdbOrganizer.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Nova\Actions\UdbOrganizer;
 
+use App\Api\ClientCredentialsContext;
 use App\Domain\Integrations\Models\IntegrationModel;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Domain\Integrations\Repositories\UdbOrganizerRepository;
 use App\Domain\Integrations\UdbOrganizer;
 use App\Domain\Integrations\UdbOrganizerStatus;
 use App\Domain\UdbUuid;
 use App\Search\Sapi3\SearchService;
+use App\UiTPAS\UiTPASApiInterface;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Collection;
@@ -29,7 +32,10 @@ final class RequestUdbOrganizer extends Action
 
     public function __construct(
         private readonly UdbOrganizerRepository $organizerRepository,
-        private readonly SearchService $searchService
+        private readonly SearchService $searchService,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly UiTPASApiInterface $UiTPASApi,
+        private readonly ClientCredentialsContext $prodContext
     ) {
     }
 
@@ -45,16 +51,31 @@ final class RequestUdbOrganizer extends Action
         }
 
         if (!$this->doesOrganizerExistInUdb($organizationId)) {
-            return Action::danger('Organisation "' . $organizationId . '" not found in UDB3.');
+            return Action::danger('Organizer "' . $organizationId . '" not found in UDB3.');
         }
 
         try {
-            $this->organizerRepository->create(new UdbOrganizer(
+            $udbOrganizer = new UdbOrganizer(
                 Uuid::uuid4(),
                 Uuid::fromString($integration->id),
                 $organizationId,
                 UdbOrganizerStatus::Approved
-            ));
+            );
+
+            $success = $this->UiTPASApi->addPermissions(
+                $this->prodContext,
+                $udbOrganizer->organizerId,
+                $this->integrationRepository
+                    ->getById($udbOrganizer->integrationId)
+                    ->getKeycloakClientByEnv($this->prodContext->environment)
+                    ->clientId
+            );
+
+            if (!$success) {
+                return Action::danger('Failed to set permissions in UiTPAS.');
+            }
+
+            $this->organizerRepository->create($udbOrganizer);
         } catch (PDOException $e) {
             if ($e->getCode() === 23000) {
                 // Handle integrity constraint violation

--- a/app/Nova/Actions/UdbOrganizer/RevokeUdbOrganizer.php
+++ b/app/Nova/Actions/UdbOrganizer/RevokeUdbOrganizer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions\UdbOrganizer;
+
+use App\Api\ClientCredentialsContext;
+use App\Domain\Integrations\Models\UdbOrganizerModel;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\Domain\Integrations\Repositories\UdbOrganizerRepository;
+use App\UiTPAS\UiTPASApiInterface;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+
+final class RevokeUdbOrganizer extends Action
+{
+    use InteractsWithQueue;
+    use Queueable;
+
+    public $name = 'Revoke UDB3 organizer permissions';
+
+    public function __construct(
+        private readonly UdbOrganizerRepository $udbOrganizerRepository,
+        private readonly IntegrationRepository $integrationRepository,
+        private readonly UiTPASApiInterface $UiTPASApi,
+        private readonly ClientCredentialsContext $prodContext,
+    ) {
+    }
+
+    public function handle(ActionFields $fields, Collection $udbOrganizers): void
+    {
+        foreach ($udbOrganizers as $udbOrganizerModel) {
+            if (!$udbOrganizerModel instanceof UdbOrganizerModel) {
+                continue;
+            }
+
+            $udbOrganizer = $udbOrganizerModel->toDomain();
+
+            $this->udbOrganizerRepository->delete($udbOrganizer->integrationId, $udbOrganizer->organizerId);
+
+            $this->UiTPASApi->deleteAllPermissions(
+                $this->prodContext,
+                $udbOrganizer->organizerId,
+                $this->integrationRepository
+                    ->getById($udbOrganizer->integrationId)
+                    ->getKeycloakClientByEnv($this->prodContext->environment)
+                    ->clientId
+            );
+        }
+    }
+}

--- a/app/Nova/Resources/Integration.php
+++ b/app/Nova/Resources/Integration.php
@@ -24,6 +24,8 @@ use App\Nova\Actions\UnblockIntegration;
 use App\Nova\Filters\AdminInformationFilter;
 use App\Nova\Resource;
 use App\Search\Sapi3\SearchService;
+use App\UiTPAS\ClientCredentialsContextFactory;
+use App\UiTPAS\UiTPASApiInterface;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -301,7 +303,13 @@ final class Integration extends Resource
                 ->canSee(fn (Request $request) => $request instanceof ActionRequest || $this->canBeUnblocked())
                 ->canRun(fn (Request $request, IntegrationModel $model) => $model->canBeUnblocked()),
 
-            (new RequestUdbOrganizer(App::make(UdbOrganizerRepository::class), App::make(SearchService::class)))
+            (new RequestUdbOrganizer(
+                App::make(UdbOrganizerRepository::class),
+                App::make(SearchService::class),
+                App::make(IntegrationRepository::class),
+                App::make(UiTPASApiInterface::class),
+                ClientCredentialsContextFactory::getUitIdProdContext(),
+            ))
                 ->exceptOnIndex()
                 ->confirmText('Are you sure you want to add an organizer?')
                 ->confirmButtonText('Add')

--- a/app/Nova/Resources/UdbOrganizer.php
+++ b/app/Nova/Resources/UdbOrganizer.php
@@ -11,6 +11,7 @@ use App\Domain\Integrations\Repositories\UdbOrganizerRepository;
 use App\Domain\Integrations\UdbOrganizerStatus;
 use App\Nova\Actions\UdbOrganizer\ApproveUdbOrganizer;
 use App\Nova\Actions\UdbOrganizer\RejectUdbOrganizer;
+use App\Nova\Actions\UdbOrganizer\RevokeUdbOrganizer;
 use App\Nova\Filters\UdbOrganizerStatusFilter;
 use App\Nova\Resource;
 use App\Search\Sapi3\SearchService;
@@ -151,14 +152,21 @@ final class UdbOrganizer extends Resource
     {
         $actions = [];
         if (config(UiTPASConfig::AUTOMATIC_PERMISSIONS_ENABLED->value)) {
-            $activateUdbOrganizer = new ApproveUdbOrganizer(
+            $approveUdbOrganizer = new ApproveUdbOrganizer(
                 App::make(UdbOrganizerRepository::class),
                 App::make(IntegrationRepository::class),
                 App::make(UiTPASApiInterface::class),
                 ClientCredentialsContextFactory::getUitIdProdContext(),
             );
 
-            $actions[] = $activateUdbOrganizer
+            $revokeUdbOrganizer = new RevokeUdbOrganizer(
+                App::make(UdbOrganizerRepository::class),
+                App::make(IntegrationRepository::class),
+                App::make(UiTPASApiInterface::class),
+                ClientCredentialsContextFactory::getUitIdProdContext(),
+            );
+
+            $actions[] = $approveUdbOrganizer
                 ->exceptOnIndex()
                 ->confirmText('Are you sure you want to active this organizer in UiTPAS?')
                 ->confirmButtonText('Activate')
@@ -173,6 +181,14 @@ final class UdbOrganizer extends Resource
                 ->cancelButtonText('Cancel')
                 ->canRun(fn (Request $request, UdbOrganizerModel $model) => $model->toDomain()->status === UdbOrganizerStatus::Pending)
                 ->canSee(fn (Request $request) => $request instanceof ActionRequest || $this->isStatusPending());
+
+            $actions[] = $revokeUdbOrganizer
+                ->exceptOnIndex()
+                ->confirmText('Are you sure you want to revoke these organizer permissions?')
+                ->confirmButtonText('Revoke')
+                ->cancelButtonText('Cancel')
+                ->canRun(fn (Request $request, UdbOrganizerModel $model) => $model->toDomain()->status === UdbOrganizerStatus::Approved)
+                ->canSee(fn (Request $request) => $request instanceof ActionRequest || $this->isStatusApproved());
         }
 
         return $actions;
@@ -181,5 +197,10 @@ final class UdbOrganizer extends Resource
     private function isStatusPending(): bool
     {
         return $this->status === UdbOrganizerStatus::Pending->value;
+    }
+
+    private function isStatusApproved(): bool
+    {
+        return $this->status === UdbOrganizerStatus::Approved->value;
     }
 }

--- a/app/Nova/Resources/UdbOrganizer.php
+++ b/app/Nova/Resources/UdbOrganizer.php
@@ -94,7 +94,15 @@ final class UdbOrganizer extends Resource
                 );
             })->asHtml(),
 
-            Text::make('status')
+            Text::make('Status', static function (UdbOrganizerModel $model) {
+                $udbOrganizerStatus = $model->toDomain()->status;
+                return sprintf(
+                    '<span style="color: %s">%s</span>',
+                    $udbOrganizerStatus === UdbOrganizerStatus::Approved ? 'green' : 'black',
+                    $udbOrganizerStatus->name
+                );
+            })
+                ->asHtml()
                 ->readonly(),
 
             Text::make('UiTPAS', static function (UdbOrganizerModel $model) {

--- a/app/UiTPAS/UiTPASApiInterface.php
+++ b/app/UiTPAS/UiTPASApiInterface.php
@@ -13,4 +13,6 @@ interface UiTPASApiInterface
     public function addPermissions(ClientCredentialsContext $context, UdbUuid $organizerId, string $clientId): bool;
 
     public function fetchPermissions(ClientCredentialsContext $context, UdbUuid $organisationId, string $clientId): ?UiTPASPermission;
+
+    public function deleteAllPermissions(ClientCredentialsContext $context, UdbUuid $organizerId, string $clientId): bool;
 }

--- a/tests/Nova/Actions/UdbOrganizer/RequestUdbOrganizerTest.php
+++ b/tests/Nova/Actions/UdbOrganizer/RequestUdbOrganizerTest.php
@@ -4,57 +4,110 @@ declare(strict_types=1);
 
 namespace Tests\Nova\Actions\UdbOrganizer;
 
-use App\Domain\Integrations\Events\UdbOrganizerCreated;
+use App\Api\ClientCredentialsContext;
+use App\Domain\Integrations\Environment;
+use App\Domain\Integrations\Integration;
 use App\Domain\Integrations\Models\IntegrationModel;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
 use App\Domain\Integrations\Repositories\UdbOrganizerRepository;
 use App\Domain\Integrations\UdbOrganizer;
+use App\Domain\UdbUuid;
+use App\Keycloak\Client;
 use App\Nova\Actions\UdbOrganizer\RequestUdbOrganizer;
 use App\Search\Sapi3\SearchService;
+use App\UiTPAS\UiTPASApiInterface;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Event;
 use Laravel\Nova\Fields\ActionFields;
+use PDOException;
 use PHPUnit\Framework\MockObject\MockObject;
+use Ramsey\Uuid\Uuid;
+use Tests\CreatesIntegration;
 use Tests\GivenUitpasOrganizers;
 use Tests\TestCase;
 
 final class RequestUdbOrganizerTest extends TestCase
 {
     use GivenUitpasOrganizers;
+    use CreatesIntegration;
 
     private const ORGANIZER_ID = 'd541dbd6-b818-432d-b2be-d51dfc5c0c51';
-    private IntegrationModel $integration;
+    private const CLIENT_ID = 'client-id';
+    private const INTEGRATION_ID = '68498691-4ff0-8010-ae61-c1ece25eaf38';
+    private IntegrationModel $integrationModel;
+    private Integration $integration;
     private RequestUdbOrganizer $handler;
-    private UdbOrganizerRepository&MockObject $repository;
+    private UdbOrganizerRepository&MockObject $udbOrganizerRepository;
+
+    private IntegrationRepository&MockObject $integrationRepository;
+    private UiTPASApiInterface&MockObject $uitpasApi;
+    private ClientCredentialsContext $context;
+    private SearchService&MockObject $searchService;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->integration = new IntegrationModel();
-        $this->integration->id = '68498691-4ff0-8010-ae61-c1ece25eaf38';
+        $this->integrationModel = new IntegrationModel();
+        $this->integrationModel->id = self::INTEGRATION_ID;
 
-        $this->repository = $this->createMock(UdbOrganizerRepository::class);
-        $searchService = $this->createMock(SearchService::class);
-        $searchService->expects($this->once())
-            ->method('findUiTPASOrganizers')
-            ->with(self::ORGANIZER_ID)
-            ->willReturn($this->givenUitpasOrganizers($this->integration->id, 'My organisation', 1));
+        $this->integration = $this->givenThereIsAnIntegration(Uuid::fromString(self::INTEGRATION_ID))
+            ->withKeycloakClients(
+                new Client(Uuid::uuid4(), Uuid::uuid4(), self::CLIENT_ID, 'secret', Environment::Production),
+            );
 
-        $this->handler = new RequestUdbOrganizer($this->repository, $searchService);
+        $this->udbOrganizerRepository = $this->createMock(UdbOrganizerRepository::class);
+
+        $this->searchService = $this->createMock(SearchService::class);
+
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
+        $this->uitpasApi = $this->createMock(UiTPASApiInterface::class);
+        $this->context = new ClientCredentialsContext(
+            Environment::Production,
+            'https://prod.publiq.be/',
+            '123',
+            'secret',
+            'uitid'
+        );
+
+        $this->handler = new RequestUdbOrganizer(
+            $this->udbOrganizerRepository,
+            $this->searchService,
+            $this->integrationRepository,
+            $this->uitpasApi,
+            $this->context,
+        );
     }
-
 
     public function test_that_it_creates_a_UdbOrganizer(): void
     {
-        $this->repository->expects($this->once())
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with(self::INTEGRATION_ID)
+            ->willReturn($this->integration);
+
+        $this->uitpasApi->expects($this->once())
+            ->method('addPermissions')
+            ->with(
+                $this->context,
+                new UdbUuid(self::ORGANIZER_ID),
+                self::CLIENT_ID
+            )
+            ->willReturn(true);
+
+        $this->searchService->expects($this->once())
+            ->method('findUiTPASOrganizers')
+            ->with(self::ORGANIZER_ID)
+            ->willReturn($this->givenUitpasOrganizers(self::INTEGRATION_ID, 'My organisation', 1));
+
+        $this->udbOrganizerRepository->expects($this->once())
             ->method('create')
             ->with($this->callback(function (UdbOrganizer $organizer) {
-                return (string)$organizer->integrationId === $this->integration->id
+                return (string)$organizer->integrationId === $this->integrationModel->id
                     && $organizer->organizerId->toString() === self::ORGANIZER_ID;
             }));
 
         $fields = new ActionFields(collect(['organizer_id' => self::ORGANIZER_ID]), collect());
-        $integrations = new Collection([$this->integration]);
+        $integrations = new Collection([$this->integrationModel]);
 
         $response = $this->handler->handle($fields, $integrations);
 
@@ -63,20 +116,89 @@ final class RequestUdbOrganizerTest extends TestCase
         $this->assertEquals('Organizer "' . self::ORGANIZER_ID . '" added.', $json['message']);
     }
 
-    public function test_it_handles_duplicates(): void
+    public function test_it_handles_invalid_udb_organisation_id(): void
     {
-        $this->repository->expects($this->once())
-            ->method('create')
-            ->willThrowException(new \PDOException('Db is on fire! Duplicate found', 23000));
+        $this->searchService->expects($this->once())
+            ->method('findUiTPASOrganizers')
+            ->with(self::ORGANIZER_ID)
+            ->willReturn($this->givenUitpasOrganizers(self::INTEGRATION_ID, 'My organisation', 0));
 
         $fields = new ActionFields(collect(['organizer_id' => self::ORGANIZER_ID]), collect());
-        $integrations = new Collection([$this->integration]);
+        $integrations = new Collection([$this->integrationModel]);
+
+        $response = $this->handler->handle($fields, $integrations);
+
+        $json = $response->jsonSerialize();
+
+        $this->assertEquals('Organizer "' . self::ORGANIZER_ID . '" not found in UDB3.', $json['danger']);
+    }
+
+    public function test_it_handles_duplicates(): void
+    {
+        $this->searchService->expects($this->once())
+            ->method('findUiTPASOrganizers')
+            ->with(self::ORGANIZER_ID)
+            ->willReturn($this->givenUitpasOrganizers(self::INTEGRATION_ID, 'My organisation', 1));
+
+        $this->uitpasApi->expects($this->once())
+            ->method('addPermissions')
+            ->with(
+                $this->context,
+                new UdbUuid(self::ORGANIZER_ID),
+                self::CLIENT_ID
+            )
+            ->willReturn(true);
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with(self::INTEGRATION_ID)
+            ->willReturn($this->integration);
+
+        $this->udbOrganizerRepository->expects($this->once())
+            ->method('create')
+            ->willThrowException(new PDOException('Db is on fire! Duplicate found', 23000));
+
+        $fields = new ActionFields(collect(['organizer_id' => self::ORGANIZER_ID]), collect());
+        $integrations = new Collection([$this->integrationModel]);
 
         $response = $this->handler->handle($fields, $integrations);
 
         $json = $response->jsonSerialize();
 
         $this->assertEquals('Organizer "' . self::ORGANIZER_ID . '" was already added.', $json['danger']);
-        Event::assertNotDispatched(UdbOrganizerCreated::class);
+    }
+
+    public function test_it_handles_failed_uitpas_permissions_call(): void
+    {
+        $this->searchService->expects($this->once())
+            ->method('findUiTPASOrganizers')
+            ->with(self::ORGANIZER_ID)
+            ->willReturn($this->givenUitpasOrganizers(self::INTEGRATION_ID, 'My organisation', 1));
+
+        $this->uitpasApi->expects($this->once())
+            ->method('addPermissions')
+            ->with(
+                $this->context,
+                new UdbUuid(self::ORGANIZER_ID),
+                self::CLIENT_ID
+            )
+            ->willReturn(false);
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with(self::INTEGRATION_ID)
+            ->willReturn($this->integration);
+
+        $this->udbOrganizerRepository->expects($this->never())
+            ->method('create');
+
+        $fields = new ActionFields(collect(['organizer_id' => self::ORGANIZER_ID]), collect());
+        $integrations = new Collection([$this->integrationModel]);
+
+        $response = $this->handler->handle($fields, $integrations);
+
+        $json = $response->jsonSerialize();
+
+        $this->assertEquals('Failed to set permissions in UiTPAS.', $json['danger']);
     }
 }

--- a/tests/Nova/Actions/UdbOrganizer/RevokeUdbOrganizerTest.php
+++ b/tests/Nova/Actions/UdbOrganizer/RevokeUdbOrganizerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Nova\Actions\UdbOrganizer;
+
+use App\Api\ClientCredentialsContext;
+use App\Domain\Integrations\Environment;
+use App\Domain\Integrations\Models\UdbOrganizerModel;
+use App\Domain\Integrations\Repositories\IntegrationRepository;
+use App\Domain\Integrations\Repositories\UdbOrganizerRepository;
+use App\Domain\Integrations\UdbOrganizerStatus;
+use App\Domain\UdbUuid;
+use App\Keycloak\Client;
+use App\Nova\Actions\UdbOrganizer\RevokeUdbOrganizer;
+use App\UiTPAS\UiTPASApiInterface;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Fields\ActionFields;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Tests\CreatesIntegration;
+use Tests\GivenUitpasOrganizers;
+
+final class RevokeUdbOrganizerTest extends TestCase
+{
+    use CreatesIntegration;
+    use GivenUitpasOrganizers;
+    private UdbOrganizerRepository&MockObject $udbOrganizerRepository;
+    private IntegrationRepository&MockObject $integrationRepository;
+    private UiTPASApiInterface&MockObject $uitpasApi;
+    private ClientCredentialsContext $context;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->udbOrganizerRepository = $this->createMock(UdbOrganizerRepository::class);
+        $this->integrationRepository = $this->createMock(IntegrationRepository::class);
+        $this->uitpasApi = $this->createMock(UiTPASApiInterface::class);
+        $this->context = new ClientCredentialsContext(
+            Environment::Production,
+            'https://prod.publiq.be/',
+            '123',
+            'secret',
+            'uitid'
+        );
+    }
+
+    public function test_it_revokes_permissions_and_deletes_udb_organizer(): void
+    {
+        $organizerId = new UdbUuid(Uuid::uuid4()->toString());
+        $integrationId = Uuid::uuid4();
+        $clientId = Uuid::uuid4();
+
+        $udbOrganizer = new UdbOrganizerModel();
+        $udbOrganizer->id = Uuid::uuid4()->toString();
+        $udbOrganizer->integration_id = $integrationId->toString();
+        $udbOrganizer->organizer_id = $organizerId->toString();
+        $udbOrganizer->status = UdbOrganizerStatus::Pending->value;
+        $udbOrganizers = new Collection();
+        $udbOrganizers->push($udbOrganizer);
+
+        $integration = $this->givenThereIsAnIntegration($integrationId)
+            ->withKeycloakClients(
+                new Client(Uuid::uuid4(), Uuid::uuid4(), $clientId->toString(), 'secret', Environment::Production),
+            );
+
+        $this->udbOrganizerRepository
+            ->expects($this->once())
+            ->method('delete')
+            ->with($integrationId, $organizerId);
+
+        $this->integrationRepository->expects($this->once())
+            ->method('getById')
+            ->with($integrationId->toString())
+            ->willReturn($integration);
+
+        $this->uitpasApi
+            ->expects($this->once())
+            ->method('deleteAllPermissions')
+            ->with($this->context, $organizerId, $clientId);
+
+        $handler = new RevokeUdbOrganizer(
+            $this->udbOrganizerRepository,
+            $this->integrationRepository,
+            $this->uitpasApi,
+            $this->context
+        );
+
+        $handler->handle(
+            new ActionFields(collect(['organizer_id' => $organizerId->toString()]), collect()),
+            new Collection([$udbOrganizer])
+        );
+    }
+}


### PR DESCRIPTION
### Added
- Added new option to an approved organizer: "revoke permissions". This will remove the organizer from the db and revoke his permissions in UiTPAS.

### Changed
- Admin added organisations are directly approved, and only recieve the final "approved" email.
- Made status field for organizer visually the same as other status fields in PPF. (color = green)

### Fixed
- UpdateStatus() organizer method was bugged, updated all data, without a where-statement.

---
Ticket: https://jira.uitdatabank.be/browse/PPF-693