### PR TITLE
PPF-686 [Frontend] Visual improvements for the organizers tab.

### DIFF
--- a/resources/translations/en.json
+++ b/resources/translations/en.json
@@ -225,6 +225,7 @@
       "pending_approval_payment": "Pending approval",
       "pending_approval_integration_description": "Approval from publiq is necessary for the live integration. All information to smoothly go live can be found <0>here</0>.",
       "pending_approval_payment_description": "Ready to work with real data and events? Activate your Search API integration (from €125 per year)",
+      "before_going_live_link": "https://docs.publiq.be/docs/uitdatabank/entry-api/getting-started",
       "here": "here.",
       "activate": "Activate"
     },

--- a/resources/translations/nl.json
+++ b/resources/translations/nl.json
@@ -224,7 +224,7 @@
       "pending_approval_integration": "In Aanvraag",
       "pending_approval_payment": "In Aanvraag",
       "pending_approval_integration_description": "Voor de live-integratie is goedkeuring van publiq nodig. Alle informatie om vlot live te kunnen gaan vind je <0>hier</0>.",
-      "before_going_live_link": "https://docs.publiq.be/docs/uitdatabank/entry-api/requirements-before-going-live",
+      "before_going_live_link": "https://docs.publiq.be/docs/uitdatabank/entry-api/getting-started",
       "pending_approval_payment_description": "Aan de slag met echte data en evenementen? Activeer je Search API integratie (vanaf 125 euro per jaar).",
       "activate": "Activatie aanvragen"
     },

--- a/resources/translations/nl.json
+++ b/resources/translations/nl.json
@@ -291,6 +291,15 @@
       "description": "Hieronder vind je een overzicht van de UiTdatabank organisaties waarvoor je acties kan uitvoeren in de UiTPAS API.",
       "no_permissions": "Geen rechten toegekend",
       "add": "Organisatie toevoegen",
+      "ask_extra_permissions": "Vraag extra rechten voor organisaties",
+      "test": {
+        "title": "Testomgeving",
+        "description": "Voor de live-integratie is goedkeuring van publiq nodig. Alle informatie om vlot live te kunnen gaan vind je <0>hier</0>. Wij geven je toegang tot een testomgeving zodat je alvast kan beginnen met ontwikkelen. Deze testomgeving bevat testdata en wordt gedeeld door alle integratoren.",
+        "link": "https://docs.publiq.be/docs/uitpas/getting-started#1-start-on-the-test-environment"
+      },
+      "live": {
+        "title": "Productieomgeving"
+      },
       "update_dialog": {
         "question": "Geef de UiTdatabank-organisaties op waarvoor je acties in UiTPAS wilt uitvoeren."
       },

--- a/resources/ts/Components/IntegrationCard.tsx
+++ b/resources/ts/Components/IntegrationCard.tsx
@@ -23,8 +23,8 @@ import { classNames } from "../utils/classNames";
 import { usePolling } from "../hooks/usePolling";
 import { ButtonSecondary } from "./ButtonSecondary";
 import { IntegrationClientCredentials } from "./IntegrationClientCredential";
-import {ButtonPrimary} from "./ButtonPrimary";
-import {router} from "@inertiajs/react";
+import { ButtonPrimary } from "./ButtonPrimary";
+import { router } from "@inertiajs/react";
 
 const productTypeToPath = {
   uitpas: "/uitpas/getting-started",
@@ -166,16 +166,17 @@ export const IntegrationCard = ({
                   />
                 )}
               </div>
-              {status === IntegrationStatus.Active && type === IntegrationType.UiTPAS && (
-                <ButtonPrimary
+              {status === IntegrationStatus.Active &&
+                type === IntegrationType.UiTPAS && (
+                  <ButtonPrimary
                     className="self-start"
                     onClick={() => {
-                        router.get(`/nl/integraties/${id}?tab=organisations`);
+                      router.get(`/nl/integraties/${id}?tab=organisations`);
                     }}
-                >
+                  >
                     {t("details.organizers_info.ask_extra_permissions")}
-                </ButtonPrimary>
-              )}
+                  </ButtonPrimary>
+                )}
             </div>
           </section>
         )}

--- a/resources/ts/Components/IntegrationCard.tsx
+++ b/resources/ts/Components/IntegrationCard.tsx
@@ -23,6 +23,8 @@ import { classNames } from "../utils/classNames";
 import { usePolling } from "../hooks/usePolling";
 import { ButtonSecondary } from "./ButtonSecondary";
 import { IntegrationClientCredentials } from "./IntegrationClientCredential";
+import {ButtonPrimary} from "./ButtonPrimary";
+import {router} from "@inertiajs/react";
 
 const productTypeToPath = {
   uitpas: "/uitpas/getting-started",
@@ -164,6 +166,16 @@ export const IntegrationCard = ({
                   />
                 )}
               </div>
+              {status === IntegrationStatus.Active && type === IntegrationType.UiTPAS && (
+                <ButtonPrimary
+                    className="self-start"
+                    onClick={() => {
+                        router.get(`/nl/integraties/${id}?tab=organisations`);
+                    }}
+                >
+                    {t("details.organizers_info.ask_extra_permissions")}
+                </ButtonPrimary>
+              )}
             </div>
           </section>
         )}

--- a/resources/ts/Components/Integrations/Detail/CredentialsAuthClients.tsx
+++ b/resources/ts/Components/Integrations/Detail/CredentialsAuthClients.tsx
@@ -12,7 +12,7 @@ import { router } from "@inertiajs/react";
 import { Link } from "../../Link";
 import { Alert } from "../../Alert";
 import { IntegrationClientCredentials } from "../../IntegrationClientCredential";
-import {IntegrationType} from "../../../types/IntegrationType";
+import { IntegrationType } from "../../../types/IntegrationType";
 
 type Props = Pick<
   Integration,
@@ -115,16 +115,17 @@ export const CredentialsAuthClients = ({
               )}
             </div>
 
-            {status === IntegrationStatus.Active && type === IntegrationType.UiTPAS && (
+            {status === IntegrationStatus.Active &&
+              type === IntegrationType.UiTPAS && (
                 <ButtonPrimary
-                className="self-start"
-                onClick={() => {
+                  className="self-start"
+                  onClick={() => {
                     router.get(`/nl/integraties/${id}?tab=organisations`);
-                }}
-              >
-                {t("details.organizers_info.ask_extra_permissions")}
-              </ButtonPrimary>
-            )}
+                  }}
+                >
+                  {t("details.organizers_info.ask_extra_permissions")}
+                </ButtonPrimary>
+              )}
           </div>
         </div>
       )}

--- a/resources/ts/Components/Integrations/Detail/CredentialsAuthClients.tsx
+++ b/resources/ts/Components/Integrations/Detail/CredentialsAuthClients.tsx
@@ -12,6 +12,7 @@ import { router } from "@inertiajs/react";
 import { Link } from "../../Link";
 import { Alert } from "../../Alert";
 import { IntegrationClientCredentials } from "../../IntegrationClientCredential";
+import {IntegrationType} from "../../../types/IntegrationType";
 
 type Props = Pick<
   Integration,
@@ -113,6 +114,17 @@ export const CredentialsAuthClients = ({
                 />
               )}
             </div>
+
+            {status === IntegrationStatus.Active && type === IntegrationType.UiTPAS && (
+                <ButtonPrimary
+                className="self-start"
+                onClick={() => {
+                    router.get(`/nl/integraties/${id}?tab=organisations`);
+                }}
+              >
+                {t("details.organizers_info.ask_extra_permissions")}
+              </ButtonPrimary>
+            )}
           </div>
         </div>
       )}

--- a/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
@@ -160,7 +160,7 @@ export const OrganizersInfo = ({ id, organizers }: Props) => {
 
   return (
     <>
-      <Heading level={4} className="font-semibold">
+      <Heading level={3} className="font-semibold">
         {t("details.organizers_info.title")}
       </Heading>
       <p>{t("details.organizers_info.description")}</p>

--- a/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Heading } from "../../Heading";
-import { useTranslation } from "react-i18next";
+import {Trans, useTranslation} from "react-i18next";
 import type { Integration } from "../../../types/Integration";
 import { Card } from "../../Card";
 import { CopyText } from "../../CopyText";
@@ -56,7 +56,7 @@ const OrganizersSection = ({
   return (
     <>
       <Heading level={4} className="font-semibold">
-        {sectionName}
+          <Trans i18nKey={`details.organizers_info.${sectionName.toLowerCase()}.title`} />
       </Heading>
       <div className="gap-0">
         {organizers.map((organizer, index) => (

--- a/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
@@ -102,7 +102,7 @@ const OrganizersSection = ({
 
             <div className="mt-2 ml-1">
               {organizer.permissions.length > 0 ? (
-                <ul className="flex flex-col gap-1 text-sm text-gray-700">
+                <ul className="grid grid-cols-1 md:grid-cols-2 gap-1 text-sm text-gray-700">
                   {organizer.permissions.map((permission, id) => (
                     <li key={id} className="flex items-start gap-2">
                       <FontAwesomeIcon

--- a/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
@@ -177,7 +177,7 @@ export const OrganizersInfo = ({ id, organizers }: Props) => {
   const byStatus = groupBy(organizers, "status");
 
   return (
-    <>
+    <div className={"flex flex-col gap-2"}>
       <Heading level={3} className="font-semibold">
         {t("details.organizers_info.title")}
       </Heading>
@@ -192,6 +192,6 @@ export const OrganizersInfo = ({ id, organizers }: Props) => {
         sectionName="Live"
         organizers={byStatus["Live"]}
       />
-    </>
+    </div>
   );
 };

--- a/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
+++ b/resources/ts/Components/Integrations/Detail/OrganizersInfo.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Heading } from "../../Heading";
-import {Trans, useTranslation} from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import type { Integration } from "../../../types/Integration";
 import { Card } from "../../Card";
 import { CopyText } from "../../CopyText";
@@ -17,6 +17,7 @@ import { OrganizersDatalist } from "./OrganizersDatalist";
 import type { UiTPASOrganizer } from "../../../types/UiTPASOrganizer";
 import { classNames } from "../../../utils/classNames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Link } from "../../Link";
 
 type Props = Integration & { organizers: Organizer[] };
 
@@ -55,9 +56,26 @@ const OrganizersSection = ({
 
   return (
     <>
-      <Heading level={4} className="font-semibold">
-          <Trans i18nKey={`details.organizers_info.${sectionName.toLowerCase()}.title`} />
+      <Heading level={4} className="font-semibold mt-4">
+        <Trans
+          i18nKey={`details.organizers_info.${sectionName.toLowerCase()}.title`}
+        />
       </Heading>
+      {sectionName !== "Live" && (
+        <p className="text-gray-600">
+          <Trans
+            i18nKey="details.organizers_info.test.description"
+            t={t}
+            components={[
+              <Link
+                key={t("details.organizers_info.test.description")}
+                href={t("details.organizers_info.test.link")}
+                className="text-publiq-blue-dark hover:underline mb-3"
+              />,
+            ]}
+          />
+        </p>
+      )}
       <div className="gap-0">
         {organizers.map((organizer, index) => (
           <Card

--- a/resources/ts/Pages/Integrations/Detail.tsx
+++ b/resources/ts/Pages/Integrations/Detail.tsx
@@ -156,14 +156,14 @@ const Detail = ({
                     oldCredentialsExpirationDate={oldCredentialsExpirationDate}
                   />
                 </Tabs.Item>
-                  {isUitpasIntegration && (
-                      <Tabs.Item
-                          type="organisations"
-                          label={t("details.organizers_info.title")}
-                      >
-                          <OrganizersInfo {...integration} organizers={organizers} />
-                      </Tabs.Item>
-                  )}
+                {isUitpasIntegration && (
+                  <Tabs.Item
+                    type="organisations"
+                    label={t("details.organizers_info.title")}
+                  >
+                    <OrganizersInfo {...integration} organizers={organizers} />
+                  </Tabs.Item>
+                )}
                 <Tabs.Item
                   type="settings"
                   label={t("details.integration_settings.title")}

--- a/resources/ts/Pages/Integrations/Detail.tsx
+++ b/resources/ts/Pages/Integrations/Detail.tsx
@@ -156,6 +156,14 @@ const Detail = ({
                     oldCredentialsExpirationDate={oldCredentialsExpirationDate}
                   />
                 </Tabs.Item>
+                  {isUitpasIntegration && (
+                      <Tabs.Item
+                          type="organisations"
+                          label={t("details.organizers_info.title")}
+                      >
+                          <OrganizersInfo {...integration} organizers={organizers} />
+                      </Tabs.Item>
+                  )}
                 <Tabs.Item
                   type="settings"
                   label={t("details.integration_settings.title")}
@@ -179,14 +187,6 @@ const Detail = ({
                     duplicateContactErrorMessage={duplicateContactErrorMessage}
                   />
                 </Tabs.Item>
-                {isUitpasIntegration && (
-                  <Tabs.Item
-                    type="organisations"
-                    label={t("details.organizers_info.title")}
-                  >
-                    <OrganizersInfo {...integration} organizers={organizers} />
-                  </Tabs.Item>
-                )}
                 <Tabs.Item
                   type="billing"
                   label={t("details.billing_info.title.billing")}


### PR DESCRIPTION
Several visual improvements for the organizers tab.

### Added
- Added new button "Vraag extra rechten voor organisaties" on the integration overview page for live integrations
- Added new button "Vraag extra rechten voor organisaties" on the integration detail page for live integrations
<img width="708" height="302" alt="Screenshot 2025-07-16 at 09 46 37" src="https://github.com/user-attachments/assets/59a32a94-67e5-4073-8251-4e760b9904ec" />

- Add new text below "test omgeving" to point to the right "get started" guide.

### Changed
- Less space between headers and text (gap distance) on organizer page.
- Change first header size to make it bigger than the other titles (h4 -> h3)
- Changed text for header "live" -> "Productie omgeving"
- Changed text for header "test -> "Test omgeving"
- Moved "organizer" tab to second slot (only visible for UiTPAS) because the tab is really important.
- Make permissions show up in 2 columns

### Fixed
- Documentation link to get started with an UDB3 integration was broken.

### Before
<img width="1896" height="927" alt="Screenshot 2025-07-16 at 09 53 50" src="https://github.com/user-attachments/assets/7a96c2d6-4ea2-4796-abce-773b01a93f02" />

### After
<img width="1887" height="917" alt="Screenshot 2025-07-16 at 09 53 35" src="https://github.com/user-attachments/assets/3d91f131-e5ef-4346-af5c-8e49a9a176d2" />

---
Ticket: https://jira.uitdatabank.be/browse/PPF-686 
