### PR TITLE
Add text on activation dialog

### DIFF
--- a/resources/translations/nl.json
+++ b/resources/translations/nl.json
@@ -249,7 +249,9 @@
         "organizers": {
           "title": "UiTdatabank organisaties",
           "info": "Geef de UiTdatabank organisaties op waarvoor je acties in UiTPAS wilt uitvoeren.",
-          "label": "Organisaties"
+          "extra_info": "Heb je nog geen UiTPAS-klant voor deze integratie, maar wil je toch al UiTPAS activeren? Stuur dan een mailtje naar <0>technical-support@publiq.be</0>.",
+          "label": "Organisaties",
+          "email": "mailto:technical-support@publiq.be"
         }
       }
     },

--- a/resources/ts/Components/ActivationDialog.tsx
+++ b/resources/ts/Components/ActivationDialog.tsx
@@ -5,7 +5,7 @@ import { ButtonPrimary } from "./ButtonPrimary";
 import { FormElement } from "./FormElement";
 import { Input } from "./Input";
 import { useForm } from "@inertiajs/react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { IntegrationType } from "../types/IntegrationType";
 import { useIsMobile } from "../hooks/useIsMobile";
 import type { Subscription } from "../types/Subscription";
@@ -16,6 +16,7 @@ import { CouponInfoContext } from "../Context/CouponInfo";
 import type { Organization } from "../types/Organization";
 import type { UiTPASOrganizer } from "../types/UiTPASOrganizer";
 import { OrganizersDatalist } from "./Integrations/Detail/OrganizersDatalist";
+import { Link } from "./Link";
 
 const PriceOverview = ({
   coupon,
@@ -275,6 +276,23 @@ export const ActivationDialog = ({
                 organizationForm.setData("organizers", organizers)
               }
             />
+            <p>
+              <Trans
+                i18nKey="integrations.activation_dialog.uitpas.organizers.extra_info"
+                t={t}
+                components={[
+                  <Link
+                    key={t(
+                      "integrations.activation_dialog.uitpas.organizers.extra_info"
+                    )}
+                    href={t(
+                      "integrations.activation_dialog.uitpas.organizers.email"
+                    )}
+                    className="text-publiq-blue-dark hover:underline mb-3"
+                  />,
+                ]}
+              />
+            </p>
           </div>
         )}
         {isBillingInfoAndPriceOverviewVisible && (


### PR DESCRIPTION
### Added
- Added small text on activation dialog


<img width="746" height="673" alt="Screenshot 2025-08-04 at 11 24 31" src="https://github.com/user-attachments/assets/906a1e26-5f59-4c91-95f3-d325c73cb55e" />

---
Ticket: https://jira.uitdatabank.be/browse/PPF-700