### PR TITLE
Remove double salutation in mail template, stop being too polite

### DIFF
--- a/resources/views/mails/integration/uitpas/created.blade.php
+++ b/resources/views/mails/integration/uitpas/created.blade.php
@@ -1,7 +1,5 @@
 @include('mails.partials.header')
 
-<p>Beste {{ $firstName }},</p>
-
 <p>Je integratie met naam {{ $integrationName }} is zonet met succes aangemaakt op het publiq platform. Je kan meteen
     starten met de ontwikkeling van je integratie op onze testomgeving. Je toegangssleutels vind je op je
     integratiepagina: <a href="{{ $integrationDetailpage }}">{{ $integrationDetailpage }}</a>.</p>


### PR DESCRIPTION
### Fixed

- Remove double salutation in mail template