### PR TITLE
Revert "[feature/OPS-1500]: upgrade node js to v22"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         }
 
         stage('Setup and build') {
-            agent { label 'ubuntu && 20.04 && php8.2 && nodejs22' }
+            agent { label 'ubuntu && 20.04 && php8.2 && nodejs18' }
             environment {
                 GIT_SHORT_COMMIT = util.shortCommitRef()
                 ARTIFACT_VERSION = "${env.PIPELINE_VERSION}" + '+sha.' + "${env.GIT_SHORT_COMMIT}"
@@ -84,7 +84,7 @@ pipeline {
         }
 
         stage('Acceptance tests') {
-            agent { label 'ubuntu && 20.04 && nodejs22' }
+            agent { label 'ubuntu && 20.04 && nodejs18' }
             environment {
                 E2E_TEST_BASE_URL      = 'https://platform-acc.publiq.be'
                 KEYCLOAK_LOGIN_ENABLED = 'true'


### PR DESCRIPTION
There are no nodes with the label ‘ubuntu&&20.04&&php8.2&&nodejs22’ https://jenkins.publiq.be/blue/organizations/jenkins/platform-api/detail/platform-api/490/pipeline/375

Reverts cultuurnet/publiq-platform#2338