### PR TITLE
PPF-747: Make dependabot work without unsecure classical token.

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,6 +3,10 @@ name: Enable automerge on dependabot PRs
 on:
   pull_request_target:
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   autoapprove:
     name: Auto-Approve a PR by dependabot

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,10 +11,10 @@ jobs:
   autoapprove:
     name: Auto-Approve a PR by dependabot
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
       - name: Auto approve
         uses: cognitedata/auto-approve-dependabot-action@v3.0.1
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -22,6 +22,7 @@ jobs:
     name: Enable automerge on dependabot PRs
     needs: autoapprove
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
       - name: Enable automerge on dependabot PRs
         uses: daneden/enable-automerge-action@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -12,7 +12,7 @@ jobs:
         uses: cognitedata/auto-approve-dependabot-action@v3.0.1
         if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
-          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   automerge:
     name: Enable automerge on dependabot PRs
@@ -22,4 +22,4 @@ jobs:
       - name: Enable automerge on dependabot PRs
         uses: daneden/enable-automerge-action@v1
         with:
-          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changed

- `dependabot-automerge.yml`: refactor workflow to work with `GITHUB_TOKEN` instead of classical token.

### Fixed

- `dependabot` should be able to automerge again.

---
Ticket: https://jira.publiq.be/browse/PPF-747
