### PR TITLE
Align react-dom with react to fix white screen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
       interval: weekly
       day: monday
       time: "02:15"
+    groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "i18next": "^26.3.6",
                 "i18next-browser-languagedetector": "^8.2.1",
                 "react": "^19.2.8",
-                "react-dom": "^19.2.7",
+                "react-dom": "^19.2.8",
                 "react-i18next": "^17.0.10",
                 "tailwind-merge": "^3.6.0"
             },
@@ -940,9 +940,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -960,9 +957,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -980,9 +974,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1000,9 +991,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1020,9 +1008,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1040,9 +1025,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4365,9 +4347,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4389,9 +4368,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4413,9 +4389,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4437,9 +4410,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5325,15 +5295,15 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.7",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.7"
+                "react": "^19.2.8"
             }
         },
         "node_modules/react-i18next": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "i18next": "^26.3.6",
         "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.2.8",
-        "react-dom": "^19.2.7",
+        "react-dom": "^19.2.8",
         "react-i18next": "^17.0.10",
         "tailwind-merge": "^3.6.0"
     },


### PR DESCRIPTION
### Fixed

- White screen on every page. `react` was bumped to 19.2.8 in #2532 while `react-dom` stayed on 19.2.7. React requires both packages to be on the exact same version and throws [error #527](https://react.dev/errors/527?args[]=19.2.8&args[]=19.2.7) at mount, so `#app` stayed empty.

  npm did not catch it at install time: `react-dom@19.2.7` declares `peer react: ^19.2.7`, which `19.2.8` satisfies. The reverse would have failed, since `react-dom@19.2.8` pins `peer react: ^19.2.8`.

### Changed

- `dependabot.yml`: group `react`, `react-dom`, `@types/react` and `@types/react-dom` into a single PR so they can never drift apart again.

---

Verified in a headless browser against `http://localhost:8000/nl`: no page errors, `#app` renders, homepage shows as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)